### PR TITLE
認証機能の修正

### DIFF
--- a/app/controllers/api/v1/authenticates_controller.rb
+++ b/app/controllers/api/v1/authenticates_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class UsersController < BaseController
+    class AuthenticatesController < BaseController
       require "googleauth"
       skip_before_action :authenticate, only: %i[create]
 

--- a/app/controllers/api/v1/authenticates_controller.rb
+++ b/app/controllers/api/v1/authenticates_controller.rb
@@ -23,6 +23,13 @@ module Api
         end
       end
 
+      def destroy
+        token = request.headers["Authorization"].split(" ")[1]
+        key = ApiKey.find_by(access_token: token)
+        key.destroy!
+        render json: { message: "signout successful" }.to_json, status: :ok
+      end
+
       private
 
       def verify_idtoken

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -17,7 +17,7 @@ module Api
 
       def authenticate
         authenticate_or_request_with_http_token do |token, _options|
-          @_current_user ||= ApiKey.active.find_by(access_token: token)&.user
+          @_current_user ||= ApiKey.find_by(access_token: token)&.user
         end
       end
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -3,11 +3,11 @@ class ApiKey < ApplicationRecord
 
   validates :access_token, presence: true, uniqueness: true
 
-  scope :active, -> { where("expires_at >= ?", Time.current) }
+  # scope :active, -> { where("expires_at >= ?", Time.current) }
 
   def initialize(attributes = {})
     super
     self.access_token = SecureRandom.uuid
-    self.expires_at = 1.week.after
+    # self.expires_at = 1.week.after
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   namespace :api, format: :json do
     namespace :v1 do
-      resources :users, only: %i[create]
+      resource :authenticate, only: %i[create]
       resources :sangakus, only: %i[index show] do
         resource :save, only: %i[create], controller: "sangaku_saves"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   namespace :api, format: :json do
     namespace :v1 do
-      resource :authenticate, only: %i[create]
+      resource :authenticate, only: %i[create destroy]
       resources :sangakus, only: %i[index show] do
         resource :save, only: %i[create], controller: "sangaku_saves"
       end

--- a/db/migrate/20250919080447_delete_expires_at_from_api_key.rb
+++ b/db/migrate/20250919080447_delete_expires_at_from_api_key.rb
@@ -1,0 +1,5 @@
+class DeleteExpiresAtFromApiKey < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :api_keys, :expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_05_065048) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_19_080447) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -36,7 +36,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_05_065048) do
 
   create_table "api_keys", force: :cascade do |t|
     t.string "access_token", null: false
-    t.datetime "expires_at"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :api_key do
     sequence(:access_token) { |n| "dummy_token_#{n}" }
-    expires_at { "2025-06-17 15:34:29" }
+    # expires_at { "2025-06-17 15:34:29" }
     association :user
   end
 end

--- a/spec/requests/api/v1/authenticates_spec.rb
+++ b/spec/requests/api/v1/authenticates_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe "Api::V1::Users", type: :request do
-  describe "Post /users" do
+RSpec.describe "Api::V1::Authenticates", type: :request do
+  describe "Post /create" do
     let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' } }
     let(:dummy_payload) { {} }
 
     before do
-      allow_any_instance_of(Api::V1::UsersController).to receive(:verify_idtoken).and_return(dummy_payload)
+      allow_any_instance_of(Api::V1::AuthenticatesController).to receive(:verify_idtoken).and_return(dummy_payload)
     end
 
     context 'user not created' do
@@ -20,7 +20,7 @@ RSpec.describe "Api::V1::Users", type: :request do
         "email" => user_attr[:email],
         "name" => user_attr[:name]
       } }
-      let(:http_request) { post api_v1_users_path, params: params, headers: headers }
+      let(:http_request) { post api_v1_authenticate_path, params: params, headers: headers }
 
       it 'returns user in json format' do
         expect { http_request }.to change(User, :count).by(1)
@@ -40,7 +40,7 @@ RSpec.describe "Api::V1::Users", type: :request do
         "name" => user.name
       } }
       let!(:params) { { token: 'dummy_idtoken' }.to_json }
-      let(:http_request) { post api_v1_users_path, params: params, headers: headers }
+      let(:http_request) { post api_v1_authenticate_path, params: params, headers: headers }
 
       it "user does not create" do
         expect { http_request }.to change(User, :count).by(0)

--- a/spec/requests/api/v1/authenticates_spec.rb
+++ b/spec/requests/api/v1/authenticates_spec.rb
@@ -49,4 +49,23 @@ RSpec.describe "Api::V1::Authenticates", type: :request do
       end
     end
   end
+
+  describe "DELETE /destroy" do
+    let!(:user) { create(:user) }
+    let!(:api_key) { create(:api_key, user:) }
+    let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' } }
+    let(:http_request) { delete api_v1_authenticate_path, headers: }
+
+    context "with access_token" do
+      let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer #{api_key.access_token}" } }
+
+      it 'return success message with json format' do
+        expect {
+          http_request
+        }.to change(ApiKey, :count).by(-1)
+        expect(response).to have_http_status(:ok)
+        expect(body["message"]).to eq "signout successful"
+      end
+    end
+  end
 end


### PR DESCRIPTION
- **change: エンドポイントの変更**
- **change: ApiKeyの有効期限を削除**
- **add: delete /api/v1/authenticateの追加**

## 概要
- ```/api/v1/users```を```/api/v1/authenticate```へ移動
- ApiKeyの有効期限を削除
- delete /api/v1/authenticateの追加

## 確認方法


## 影響範囲


## チェックリスト

- [ ] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] request specをパスした
- [ ] 必要なドキュメントを作成した

## コメント

