### PR TITLE
change: 算額の写し一覧から解答済みを除外

### DIFF
--- a/app/controllers/api/v1/user/saved_sangakus_controller.rb
+++ b/app/controllers/api/v1/user/saved_sangakus_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class User::SavedSangakusController < BaseController
       def index
-        saved_sangakus = current_user.saved_sangakus.search(search_params).includes(:fixed_inputs, :user)
+        saved_sangakus = current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user)
         render json: SangakuSerializer.new(saved_sangakus).serializable_hash.to_json
       end
 

--- a/doc/openapi/user/saved_sangakus.yaml
+++ b/doc/openapi/user/saved_sangakus.yaml
@@ -12,7 +12,7 @@ paths:
       - Api::V1::SangakuSave
       responses:
         '200':
-          description: return sangakus in json format
+          description: return unsolved saved sangakus in json format
           content:
             application/json:
               schema:
@@ -73,6 +73,15 @@ paths:
                               properties:
                                 data:
                                   nullable: true
+                                  type: object
+                                  properties:
+                                    id:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - id
+                                  - type
                               required:
                               - data
                           required:
@@ -87,7 +96,7 @@ paths:
                 - data
               example:
                 data:
-                - id: '1019'
+                - id: '41'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -99,10 +108,12 @@ paths:
                   relationships:
                     user:
                       data:
-                        id: '1619'
+                        id: '68'
                         type: user
                     shrine:
                       data:
+                        id: '24'
+                        type: shrine
   "/api/v1/user/saved_sangakus/{id}":
     get:
       summary: show
@@ -114,7 +125,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 1020
+        example: 43
       responses:
         '200':
           description: return sangaku in json format
@@ -190,7 +201,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '1020'
+                  id: '43'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -202,7 +213,7 @@ paths:
                   relationships:
                     user:
                       data:
-                        id: '1621'
+                        id: '70'
                         type: user
                     shrine:
                       data:

--- a/spec/requests/api/v1/user/saved_sangakus_spec.rb
+++ b/spec/requests/api/v1/user/saved_sangakus_spec.rb
@@ -6,18 +6,23 @@ RSpec.describe "Api::V1::User::SavedSangakus", type: :request, openapi: {
   describe "GET /index" do
     let!(:user) { create(:user) }
     let!(:author) { create(:user, nickname: "author") }
-    let!(:sangaku) { create(:sangaku, user: author) }
+    let!(:shrine) { create(:shrine) }
+    let!(:sangaku) { create(:sangaku, user: author, shrine:) }
     let!(:sangaku_save_relation) { create(:user_sangaku_save, sangaku:, user: user) }
+    let!(:answered_sangaku) { create(:sangaku, title: "answerd", user: author, shrine:) }
+    let!(:answered_sangaku_save_relation) { create(:user_sangaku_save, sangaku: answered_sangaku, user: user) }
+    let!(:answer) { create(:answer, user_sangaku_save: answered_sangaku_save_relation)}
     let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
     let(:http_request) { get api_v1_user_saved_sangakus_path, headers: }
 
     context "with access_token" do
-      it 'return sangakus in json format' do
+      it 'return unsolved saved sangakus in json format' do
         authenticate_stub(user)
         http_request
 
         expect(response).to be_successful
         expect(response).to have_http_status(:ok)
+        expect(body["data"].count).to eq 1
         expect(body["data"][0]["attributes"]["title"]).to eq sangaku.title
         expect(body["data"][0]["attributes"]["author_name"]).to eq author.nickname
       end

--- a/spec/requests/api/v1/user/saved_sangakus_spec.rb
+++ b/spec/requests/api/v1/user/saved_sangakus_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Api::V1::User::SavedSangakus", type: :request, openapi: {
     let!(:sangaku_save_relation) { create(:user_sangaku_save, sangaku:, user: user) }
     let!(:answered_sangaku) { create(:sangaku, title: "answerd", user: author, shrine:) }
     let!(:answered_sangaku_save_relation) { create(:user_sangaku_save, sangaku: answered_sangaku, user: user) }
-    let!(:answer) { create(:answer, user_sangaku_save: answered_sangaku_save_relation)}
+    let!(:answer) { create(:answer, user_sangaku_save: answered_sangaku_save_relation) }
     let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
     let(:http_request) { get api_v1_user_saved_sangakus_path, headers: }
 


### PR DESCRIPTION
## 概要

- ```GET /api/v1/user/saved_sangakus```のレスポンスから解答済みの算額を除外

## 確認方法

1. サーバーを立ち上げ、consoleを利用して算額の写しと解答を作成してください
2. ```GET /api/v1/user/saved_sangakus```へaccess_tokenを含めてリクエストを送り、解答済みの算額が含まれないことを確認してください

## 影響範囲


## チェックリスト

- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした
- [x] reqest specをパスした
- [ ] 必要なドキュメントを作成した

## コメント

