### PR TITLE
change: /user/saved_sangakusに条件分岐を追加

### DIFF
--- a/app/controllers/api/v1/user/saved_sangakus_controller.rb
+++ b/app/controllers/api/v1/user/saved_sangakus_controller.rb
@@ -2,7 +2,13 @@ module Api
   module V1
     class User::SavedSangakusController < BaseController
       def index
-        saved_sangakus = current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user)
+        if params[:type] == "answered"
+          saved_sangakus = current_user.saved_sangakus.left_joins(:answers).where.not(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user)
+        elsif params[:type] == "before_answer"
+          saved_sangakus = current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user)
+        else
+          saved_sangakus = current_user.saved_sangakus.inculdes(:fixed_inputs, :user)
+        end
         render json: SangakuSerializer.new(saved_sangakus).serializable_hash.to_json
       end
 

--- a/doc/openapi/user/saved_sangakus.yaml
+++ b/doc/openapi/user/saved_sangakus.yaml
@@ -96,7 +96,7 @@ paths:
                 - data
               example:
                 data:
-                - id: '41'
+                - id: '148'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -108,12 +108,19 @@ paths:
                   relationships:
                     user:
                       data:
-                        id: '68'
+                        id: '239'
                         type: user
                     shrine:
                       data:
-                        id: '24'
+                        id: '94'
                         type: shrine
+      parameters:
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+        example: before_answer
   "/api/v1/user/saved_sangakus/{id}":
     get:
       summary: show
@@ -125,7 +132,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 43
+        example: 150
       responses:
         '200':
           description: return sangaku in json format
@@ -201,7 +208,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '43'
+                  id: '150'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -213,7 +220,7 @@ paths:
                   relationships:
                     user:
                       data:
-                        id: '70'
+                        id: '241'
                         type: user
                     shrine:
                       data:

--- a/spec/requests/api/v1/user/saved_sangakus_spec.rb
+++ b/spec/requests/api/v1/user/saved_sangakus_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "Api::V1::User::SavedSangakus", type: :request, openapi: {
     let!(:answered_sangaku_save_relation) { create(:user_sangaku_save, sangaku: answered_sangaku, user: user) }
     let!(:answer) { create(:answer, user_sangaku_save: answered_sangaku_save_relation) }
     let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
-    let(:http_request) { get api_v1_user_saved_sangakus_path, headers: }
+    let(:params) { { type: "before_answer" } }
+    let(:http_request) { get api_v1_user_saved_sangakus_path, headers:, params: }
 
     context "with access_token" do
       it 'return unsolved saved sangakus in json format' do


### PR DESCRIPTION
クエリパラメータによる解答前、済みの絞り込みを追加

## 概要
- ```GET /api/v1/user/saved_sangakus```にクエリパラメータによる解答前、済みの絞り込みを追加

## 確認方法
1. ```GET /api/v1/user/saved_sangakus```にリクエストを送信しユーザーの解答前、済み全ての算額の写しが返却されることを確認してください
2. クエリパラメータに```type=before_answer```を追加し、解答前の算額のみが返却されることを確認してください

## 影響範囲


## チェックリスト


- [ ] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] request specをパスした
- [ ] 必要なドキュメントを作成した

## コメント

