### PR TITLE
fix: terraform の数字付きバックアップファイルを .gitignore に追加

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,6 +1,7 @@
 # Terraform State (ローカル管理 - 機密情報を含む)
 terraform.tfstate
 terraform.tfstate.backup
+terraform.tfstate.*.backup
 
 # 実際の変数値 (機密情報を含む)
 terraform.tfvars


### PR DESCRIPTION
## 概要

`terraform apply` が失敗した際などに生成される数字付きバックアップファイル（例: `terraform.tfstate.1775708981.backup`）が Git に追跡されてしまう問題を修正。

`.gitignore` に `terraform.tfstate.*.backup` パターンを追加することで、今後同様のファイルが生成されても自動的に除外されるようにした。

## 確認方法

1. `back/terraform/.gitignore` に `terraform.tfstate.*.backup` が追加されていることを確認する
2. `git status` で `terraform.tfstate.*.backup` 形式のファイルが untracked に出ないことを確認する

## 影響範囲

- `back/terraform/.gitignore` のみ
- インフラ・アプリケーションコードへの影響なし

## チェックリスト

- [ ] siderをパスした
- [ ] インテグレーションテストを追加した
- [ ] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] 必要なドキュメントを作成した

## コメント

既存の `terraform.tfstate.backup` は `.gitignore` 対象だったが、数字付きのパターンが漏れていた。