### PR TITLE
feat: 算額コード生成APIにユーザー単位の1日あたり利用回数制限を追加

### DIFF
--- a/app/controllers/api/v1/user/sangakus_controller.rb
+++ b/app/controllers/api/v1/user/sangakus_controller.rb
@@ -47,6 +47,13 @@ module Api
           return render json: { error: "問題文は#{GENERATE_SOURCE_MAX_LENGTH}文字以内で入力してください" }, status: :unprocessable_entity
         end
 
+        if current_user.generate_source_daily_remaining <= 0
+          return render json: {
+            error: "本日の利用回数上限に達しました",
+            reset_at: current_user.generate_source_daily_reset_at.iso8601
+          }, status: :too_many_requests
+        end
+
         client = OpenAI::Client.new
         response = client.chat(
           parameters: {
@@ -76,9 +83,34 @@ module Api
         )
 
         source = response.dig("choices", 0, "message", "content")
-        render json: { source: source }, status: :ok
+        if source.blank?
+          return render json: { error: "コードの生成に失敗しました" }, status: :unprocessable_entity
+        end
+
+        now = Time.current
+        current_user.generate_source_call_logs.create!(called_at: now)
+
+        render json: {
+          source: source,
+          usage: {
+            used: current_user.generate_source_daily_used_count(now),
+            limit: current_user.generate_source_daily_limit,
+            remaining: current_user.generate_source_daily_remaining(now),
+            reset_at: current_user.generate_source_daily_reset_at(now).iso8601
+          }
+        }, status: :ok
       rescue OpenAI::Error => e
         render json: { error: e.message }, status: :unprocessable_entity
+      end
+
+      def generate_source_usage
+        now = Time.current
+        render json: {
+          used: current_user.generate_source_daily_used_count(now),
+          limit: current_user.generate_source_daily_limit,
+          remaining: current_user.generate_source_daily_remaining(now),
+          reset_at: current_user.generate_source_daily_reset_at(now).iso8601
+        }, status: :ok
       end
 
       private

--- a/app/models/generate_source_call_log.rb
+++ b/app/models/generate_source_call_log.rb
@@ -1,0 +1,25 @@
+class GenerateSourceCallLog < ApplicationRecord
+  belongs_to :user
+
+  validates :called_at, presence: true
+
+  def self.current_day_range(now = Time.current)
+    day_start = current_day_start(now)
+    day_start...next_reset_time(now)
+  end
+
+  def self.next_reset_time(now = Time.current)
+    current_day_start(now) + 1.day
+  end
+
+  def self.current_day_start(now = Time.current)
+    jst_now = now.in_time_zone("Asia/Tokyo")
+    boundary_hour = 3
+
+    if jst_now.hour < boundary_hour
+      jst_now.beginning_of_day.change(hour: boundary_hour) - 1.day
+    else
+      jst_now.beginning_of_day.change(hour: boundary_hour)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,25 @@ class User < ApplicationRecord
   has_many :saved_sangakus, through: :user_sangaku_saves, source: :sangaku
   has_many :answers, through: :user_sangaku_saves
   has_many :answer_results, through: :answers
+  has_many :generate_source_call_logs, dependent: :destroy
+
+  GENERATE_SOURCE_DAILY_LIMIT_DEFAULT = 5
+
+  def generate_source_daily_limit
+    GENERATE_SOURCE_DAILY_LIMIT_DEFAULT
+  end
+
+  def generate_source_daily_used_count(now = Time.current)
+    generate_source_call_logs.where(called_at: GenerateSourceCallLog.current_day_range(now)).count
+  end
+
+  def generate_source_daily_remaining(now = Time.current)
+    [generate_source_daily_limit - generate_source_daily_used_count(now), 0].max
+  end
+
+  def generate_source_daily_reset_at(now = Time.current)
+    GenerateSourceCallLog.next_reset_time(now)
+  end
 
   validates :provider, presence: true, length: { maximum: 255 }
   validates :uid, presence: true, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   end
 
   def generate_source_daily_remaining(now = Time.current)
-    [generate_source_daily_limit - generate_source_daily_used_count(now), 0].max
+    [ generate_source_daily_limit - generate_source_daily_used_count(now), 0 ].max
   end
 
   def generate_source_daily_reset_at(now = Time.current)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
         resources :sangakus, only: %i[index show create update destroy], shallow: true do
           collection do
             post :generate_source
+            get :generate_source_usage
           end
           resource :result, only: %i[show]
           resource :dedicate, only: %i[create]

--- a/db/migrate/20260410225255_create_generate_source_call_logs.rb
+++ b/db/migrate/20260410225255_create_generate_source_call_logs.rb
@@ -7,6 +7,6 @@ class CreateGenerateSourceCallLogs < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :generate_source_call_logs, [:user_id, :called_at]
+    add_index :generate_source_call_logs, [ :user_id, :called_at ]
   end
 end

--- a/db/migrate/20260410225255_create_generate_source_call_logs.rb
+++ b/db/migrate/20260410225255_create_generate_source_call_logs.rb
@@ -1,0 +1,12 @@
+class CreateGenerateSourceCallLogs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :generate_source_call_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.datetime :called_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :generate_source_call_logs, [:user_id, :called_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_26_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -52,6 +52,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_26_000000) do
     t.datetime "updated_at", null: false
     t.index ["content", "sangaku_id"], name: "index_fixed_inputs_on_content_and_sangaku_id", unique: true
     t.index ["sangaku_id"], name: "index_fixed_inputs_on_sangaku_id"
+  end
+
+  create_table "generate_source_call_logs", force: :cascade do |t|
+    t.datetime "called_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id", "called_at"], name: "index_generate_source_call_logs_on_user_id_and_called_at"
+    t.index ["user_id"], name: "index_generate_source_call_logs_on_user_id"
   end
 
   create_table "sangakus", force: :cascade do |t|
@@ -226,6 +235,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_26_000000) do
   add_foreign_key "answers", "user_sangaku_saves", column: "user_sangaku_save_id"
   add_foreign_key "api_keys", "users"
   add_foreign_key "fixed_inputs", "sangakus"
+  add_foreign_key "generate_source_call_logs", "users"
   add_foreign_key "sangakus", "shrines"
   add_foreign_key "sangakus", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/doc/openapi/user/sangakus.yaml
+++ b/doc/openapi/user/sangakus.yaml
@@ -96,7 +96,7 @@ paths:
                 - data
               example:
                 data:
-                - id: '33'
+                - id: '116'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -108,18 +108,20 @@ paths:
                   relationships:
                     user:
                       data:
-                        id: '34'
+                        id: '240'
                         type: user
                     shrine:
                       data:
-                        id: '12'
+                        id: '47'
                         type: shrine
       parameters:
       - name: shrine_id
         in: query
         required: false
         schema:
-          type: string
+          oneOf:
+          - type: string
+          - type: integer
         example: any
       - name: title
         in: query
@@ -252,7 +254,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '36'
+                  id: '119'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -260,13 +262,13 @@ paths:
                     source: puts 'Hello world'
                     difficulty: easy
                     inputs:
-                    - id: 3
+                    - id: 12
                       content: test_input_1
                     author_name: test nickname
                   relationships:
                     user:
                       data:
-                        id: '36'
+                        id: '242'
                         type: user
                     shrine:
                       data:
@@ -289,7 +291,7 @@ paths:
               description: 1からnまでの合計を計算して出力してください
       responses:
         '200':
-          description: calls OpenAI API with description
+          description: calls OpenAI API with wrapped description
           content:
             application/json:
               schema:
@@ -297,6 +299,22 @@ paths:
                 properties:
                   source:
                     type: string
+                  usage:
+                    type: object
+                    properties:
+                      used:
+                        type: integer
+                      limit:
+                        type: integer
+                      remaining:
+                        type: integer
+                      reset_at:
+                        type: string
+                    required:
+                    - used
+                    - limit
+                    - remaining
+                    - reset_at
                 required:
                 - source
               example:
@@ -304,6 +322,42 @@ paths:
                   # 対応言語: Ruby
                   n = gets.chomp.to_i
                   puts (1..n).sum
+                usage:
+                  used: 1
+                  limit: 5
+                  remaining: 4
+                  reset_at: '2026-04-12T03:00:00+09:00'
+  "/api/v1/user/sangakus/generate_source_usage":
+    get:
+      summary: generate_source_usage
+      tags:
+      - Api::V1::User::Sangaku
+      responses:
+        '200':
+          description: does not count other users' logs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  used:
+                    type: integer
+                  limit:
+                    type: integer
+                  remaining:
+                    type: integer
+                  reset_at:
+                    type: string
+                required:
+                - used
+                - limit
+                - remaining
+                - reset_at
+              example:
+                used: 0
+                limit: 5
+                remaining: 5
+                reset_at: '2026-04-12T03:00:00+09:00'
   "/api/v1/user/sangakus/{id}":
     delete:
       summary: destroy
@@ -315,7 +369,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 40
+        example: 123
       responses:
         '200':
           description: return sangaku in json format
@@ -391,7 +445,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '40'
+                  id: '123'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -403,7 +457,7 @@ paths:
                   relationships:
                     user:
                       data:
-                        id: '42'
+                        id: '248'
                         type: user
                     shrine:
                       data:
@@ -417,7 +471,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 37
+        example: 120
       responses:
         '200':
           description: return sangaku in json formata
@@ -493,7 +547,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '37'
+                  id: '120'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -505,7 +559,7 @@ paths:
                   relationships:
                     user:
                       data:
-                        id: '37'
+                        id: '243'
                         type: user
                     shrine:
                       data:
@@ -519,7 +573,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 38
+        example: 121
       requestBody:
         content:
           application/json:
@@ -641,7 +695,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '38'
+                  id: '121'
                   type: sangaku
                   attributes:
                     title: changed_title
@@ -649,13 +703,13 @@ paths:
                     source: puts 'Hello world'
                     difficulty: easy
                     inputs:
-                    - id: 4
+                    - id: 13
                       content: a
                     author_name: test nickname
                   relationships:
                     user:
                       data:
-                        id: '38'
+                        id: '244'
                         type: user
                     shrine:
                       data:

--- a/spec/factories/generate_source_call_logs.rb
+++ b/spec/factories/generate_source_call_logs.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :generate_source_call_log do
+    user
+    called_at { Time.current }
+  end
+end

--- a/spec/models/generate_source_call_log_spec.rb
+++ b/spec/models/generate_source_call_log_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe GenerateSourceCallLog, type: :model do
+  describe "associations" do
+    it "belongs to user" do
+      log = build(:generate_source_call_log)
+      expect(log.user).to be_a(User)
+    end
+  end
+
+  describe "validations" do
+    it "is invalid without called_at" do
+      log = build(:generate_source_call_log, called_at: nil)
+      expect(log).to be_invalid
+      expect(log.errors[:called_at]).to be_present
+    end
+  end
+
+  describe ".current_day_range" do
+    context "when JST time is 2:59:59 (before boundary)" do
+      it "returns range from previous day 3:00 to current day 3:00" do
+        now = ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 10, 2, 59, 59) # JST 2:59:59
+
+        range = described_class.current_day_range(now)
+
+        expect(range.begin).to eq ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 9, 3, 0, 0)
+        expect(range.end).to eq ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 10, 3, 0, 0)
+      end
+    end
+
+    context "when JST time is exactly 3:00:00 (at boundary)" do
+      it "returns range from current day 3:00 to next day 3:00" do
+        now = ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 10, 3, 0, 0) # JST 3:00:00
+
+        range = described_class.current_day_range(now)
+
+        expect(range.begin).to eq ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 10, 3, 0, 0)
+        expect(range.end).to eq ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 11, 3, 0, 0)
+      end
+    end
+
+    context "when JST time is 10:00 (well after boundary)" do
+      it "returns range from current day 3:00 to next day 3:00" do
+        now = ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 10, 10, 0, 0) # JST 10:00
+
+        range = described_class.current_day_range(now)
+
+        expect(range.begin).to eq ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 10, 3, 0, 0)
+        expect(range.end).to eq ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 11, 3, 0, 0)
+      end
+    end
+
+    context "end is exclusive" do
+      it "does not include a log at exactly the end boundary (next day 3:00:00)" do
+        now = ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 10, 10, 0, 0)
+        range = described_class.current_day_range(now)
+
+        expect(range).not_to cover(ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 11, 3, 0, 0))
+      end
+
+      it "includes a log 1 second before the end boundary" do
+        now = ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 10, 10, 0, 0)
+        range = described_class.current_day_range(now)
+
+        expect(range).to cover(ActiveSupport::TimeZone["Asia/Tokyo"].local(2026, 4, 11, 2, 59, 59))
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe User, type: :model do
     end
 
     it "is invalid without email" do
-      user = build(:user, name: '')
+      user = build(:user, email: '')
       expect(user).to be_invalid
-      expect(user.errors[:name]).to eq [ 'を入力してください' ]
+      expect(user.errors[:email]).to eq [ 'を入力してください' ]
     end
 
     it "is invalid without nickname" do
@@ -86,6 +86,83 @@ RSpec.describe User, type: :model do
       another_user = build(:user, email: user.nickname)
       expect(another_user).to be_valid
       expect(another_user.errors).to be_empty
+    end
+  end
+
+  describe "generate_source rate limit methods" do
+    let(:user) { create(:user) }
+
+    describe "#generate_source_daily_limit" do
+      it "returns the default daily limit" do
+        expect(user.generate_source_daily_limit).to eq User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT
+      end
+    end
+
+    describe "#generate_source_daily_used_count" do
+      context "when no logs exist" do
+        it "returns 0" do
+          expect(user.generate_source_daily_used_count).to eq 0
+        end
+      end
+
+      context "when logs exist within the current day range" do
+        before do
+          travel_to Time.zone.local(2026, 4, 10, 10, 0, 0) do
+            create(:generate_source_call_log, user: user, called_at: Time.current)
+            create(:generate_source_call_log, user: user, called_at: Time.current - 1.hour)
+          end
+        end
+
+        it "counts only logs within the current day range" do
+          travel_to Time.zone.local(2026, 4, 10, 11, 0, 0) do
+            expect(user.generate_source_daily_used_count).to eq 2
+          end
+        end
+      end
+
+      context "when logs exist outside the current day range" do
+        before do
+          create(:generate_source_call_log, user: user, called_at: Time.zone.local(2026, 4, 9, 10, 0, 0))
+        end
+
+        it "does not count logs from previous day" do
+          travel_to Time.zone.local(2026, 4, 10, 10, 0, 0) do
+            expect(user.generate_source_daily_used_count).to eq 0
+          end
+        end
+      end
+    end
+
+    describe "#generate_source_daily_remaining" do
+      context "when used count is below limit" do
+        before do
+          create(:generate_source_call_log, user: user, called_at: Time.current)
+        end
+
+        it "returns limit minus used count" do
+          expect(user.generate_source_daily_remaining).to eq User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT - 1
+        end
+      end
+
+      context "when used count equals limit" do
+        before do
+          User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT.times do
+            create(:generate_source_call_log, user: user, called_at: Time.current)
+          end
+        end
+
+        it "returns 0" do
+          expect(user.generate_source_daily_remaining).to eq 0
+        end
+      end
+    end
+
+    describe "#generate_source_daily_reset_at" do
+      it "returns the end of the current day range" do
+        travel_to Time.zone.local(2026, 4, 10, 10, 0, 0) do
+          expect(user.generate_source_daily_reset_at).to eq Time.zone.local(2026, 4, 11, 3, 0, 0)
+        end
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,4 +76,5 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ResponseHelper
   config.include AuthenticationHelper
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/requests/api/v1/user/sangakus_spec.rb
+++ b/spec/requests/api/v1/user/sangakus_spec.rb
@@ -249,11 +249,17 @@ RSpec.describe "Api::V1::User::Sangakus", type: :request do
     end
 
     context "with valid token" do
-      it "returns generated source code" do
+      it "returns generated source code with usage" do
         authenticate_stub(user)
-        http_request
+        expect {
+          http_request
+        }.to change(GenerateSourceCallLog, :count).by(1)
         expect(response).to have_http_status(:ok)
         expect(body["source"]).to eq generated_source
+        expect(body["usage"]["used"]).to eq 1
+        expect(body["usage"]["limit"]).to eq User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT
+        expect(body["usage"]["remaining"]).to eq User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT - 1
+        expect(body["usage"]["reset_at"]).to be_present
       end
 
       it "calls OpenAI API with wrapped description" do
@@ -269,13 +275,33 @@ RSpec.describe "Api::V1::User::Sangakus", type: :request do
       end
     end
 
+    context "when daily limit is reached", openapi: false do
+      before do
+        User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT.times do
+          create(:generate_source_call_log, user: user, called_at: Time.current)
+        end
+      end
+
+      it "returns 429 without creating a log" do
+        authenticate_stub(user)
+        expect {
+          http_request
+        }.not_to change(GenerateSourceCallLog, :count)
+        expect(response).to have_http_status(:too_many_requests)
+        expect(body["error"]).to be_present
+        expect(body["reset_at"]).to be_present
+      end
+    end
+
     context "when description exceeds max length", openapi: false do
       let(:description) { "a" * 2001 }
 
-      it "returns 422 without calling OpenAI API" do
+      it "returns 422 without calling OpenAI API and without creating a log" do
         authenticate_stub(user)
         expect_any_instance_of(OpenAI::Client).not_to receive(:chat)
-        http_request
+        expect {
+          http_request
+        }.not_to change(GenerateSourceCallLog, :count)
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
@@ -304,10 +330,72 @@ RSpec.describe "Api::V1::User::Sangakus", type: :request do
         allow_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(OpenAI::Error)
       end
 
-      it "returns 422" do
+      it "returns 422 without creating a log" do
+        authenticate_stub(user)
+        expect {
+          http_request
+        }.not_to change(GenerateSourceCallLog, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "JST 3:00 boundary behavior", openapi: false do
+      it "counts logs only within the current JST day window" do
+        authenticate_stub(user)
+        travel_to Time.zone.local(2026, 4, 10, 2, 59, 59) do
+          create(:generate_source_call_log, user: user, called_at: Time.current)
+        end
+
+        travel_to Time.zone.local(2026, 4, 10, 3, 0, 0) do
+          http_request
+          expect(response).to have_http_status(:ok)
+          expect(body["usage"]["used"]).to eq 1
+        end
+      end
+    end
+  end
+
+  describe "GET /user/sangakus/generate_source_usage" do
+    let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
+    let!(:user) { create(:user) }
+    let(:http_request) { get generate_source_usage_api_v1_user_sangakus_path, headers: headers }
+
+    context "with valid token" do
+      it "returns usage information" do
         authenticate_stub(user)
         http_request
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:ok)
+        expect(body["used"]).to eq 0
+        expect(body["limit"]).to eq User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT
+        expect(body["remaining"]).to eq User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT
+        expect(body["reset_at"]).to be_present
+      end
+
+      it "reflects existing call logs" do
+        create(:generate_source_call_log, user: user, called_at: Time.current)
+        authenticate_stub(user)
+        http_request
+        expect(response).to have_http_status(:ok)
+        expect(body["used"]).to eq 1
+        expect(body["remaining"]).to eq User::GENERATE_SOURCE_DAILY_LIMIT_DEFAULT - 1
+      end
+
+      it "does not count other users' logs" do
+        another_user = create(:user)
+        create(:generate_source_call_log, user: another_user, called_at: Time.current)
+        authenticate_stub(user)
+        http_request
+        expect(response).to have_http_status(:ok)
+        expect(body["used"]).to eq 0
+      end
+    end
+
+    context "without token", openapi: false do
+      let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' } }
+
+      it "returns 401" do
+        http_request
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end


### PR DESCRIPTION
## 概要

`POST /api/v1/user/sangakus/generate_source`（OpenAI GPT-4o-mini を用いたコード生成）にユーザー単位の1日5回制限を追加しました。

関連 Issue: Alnoir-0011/algo_sangaku#215

## 確認方法

1. マイグレーションを実行してください
   ```bash
   docker-compose exec web bundle exec rails db:migrate
   ```
2. `POST /api/v1/user/sangakus/generate_source` を5回呼び出すと、6回目から 429 が返ることを確認してください
3. JST 翌日 3:00 以降にリセットされることを確認してください
4. `GET /api/v1/user/sangakus/generate_source_usage` で現在の残数が取得できることを確認してください

## 影響範囲

- `POST /api/v1/user/sangakus/generate_source`
  - レスポンスに `usage`（used / limit / remaining / reset_at）を追加
  - 上限超過時に 429 を返す（既存の 200/422 は維持）
- `GET /api/v1/user/sangakus/generate_source_usage`（新規エンドポイント）
- `generate_source_call_logs` テーブル新規追加

## チェックリスト

- [ ] siderをパスした
- [x] インテグレーションテストを追加した
- [ ] Lint のチェックをパスした
- [x] ユニットテストをパスした
- [x] 必要なドキュメントを作成した（OpenAPI doc 更新済み）

## コメント

- JST 3:00 境界のリセット計算は `GenerateSourceCallLog.current_day_range` / `next_reset_time` に集約しています
- 同時リクエストによる上限 +1 回の突破は issue 仕様上の非目標として許容しています（`generate_source_call_logs` テーブルへの insert で制御しています）
- OpenAI が `choices` 空を返した場合（コンテンツフィルタ等）はログを作成せず 422 を返します