### PR TITLE
feat: ユーザープロフィール画面のバックエンド実装

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1
+    class ProfilesController < BaseController
+      skip_before_action :authenticate
+
+      def show
+        user = ::User.find(params[:id])
+        render json: ProfileSerializer.new(user).serializable_hash.to_json
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/shrines_sangakus_controller.rb
+++ b/app/controllers/api/v1/shrines_sangakus_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       def index
         shrine = Shrine.find(params[:shrine_id])
-        @pagy, sangakus = pagy(shrine.sangakus.search(search_params).includes(:fixed_inputs, :user))
+        @pagy, sangakus = pagy(shrine.sangakus.search(search_params).includes(:fixed_inputs, :user, :shrine))
         render json: SangakuSerializer.new(sangakus).serializable_hash.to_json, status: :ok
       end
 

--- a/app/controllers/api/v1/user/profiles_controller.rb
+++ b/app/controllers/api/v1/user/profiles_controller.rb
@@ -1,6 +1,10 @@
 module Api
   module V1
     class User::ProfilesController < BaseController
+      def show
+        render json: MyProfileSerializer.new(current_user).serializable_hash.to_json
+      end
+
       def update
         user = ::User.find(current_user.id)
 

--- a/app/controllers/api/v1/user/profiles_controller.rb
+++ b/app/controllers/api/v1/user/profiles_controller.rb
@@ -14,7 +14,7 @@ module Api
       private
 
       def user_params
-        params.require(:user).permit(:nickname)
+        params.require(:user).permit(:nickname, :show_answer_count)
       end
     end
   end

--- a/app/controllers/api/v1/user/sangakus_controller.rb
+++ b/app/controllers/api/v1/user/sangakus_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :set_sangaku, only: %i[show update destroy]
 
       def index
-        @pagy, sangakus = pagy(current_user.sangakus.search(search_params).includes(:fixed_inputs, :user))
+        @pagy, sangakus = pagy(current_user.sangakus.search(search_params).includes(:fixed_inputs, :user, :shrine))
         render json: SangakuSerializer.new(sangakus).serializable_hash.to_json, status: :ok
       end
 

--- a/app/controllers/api/v1/user/saved_sangakus_controller.rb
+++ b/app/controllers/api/v1/user/saved_sangakus_controller.rb
@@ -3,13 +3,13 @@ module Api
     class User::SavedSangakusController < BaseController
       def index
         if params[:type] == "answered"
-          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.left_joins(:answers).where.not(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user))
+          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.left_joins(:answers).where.not(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user, :shrine))
           render json: SangakuSerializer.new(saved_sangakus).serializable_hash.to_json
         elsif params[:type] == "before_answer"
-          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user))
+          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user, :shrine))
           render json: SangakuSerializer.new(saved_sangakus).serializable_hash.to_json
         else
-          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.includes(:fixed_inputs, :user))
+          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.includes(:fixed_inputs, :user, :shrine))
           render json: SangakuSerializer.new(saved_sangakus).serializable_hash.to_json
         end
       end

--- a/app/models/sangaku.rb
+++ b/app/models/sangaku.rb
@@ -18,7 +18,7 @@ class Sangaku < ApplicationRecord
   validate :fixed_inputs_uniqueness
 
   enum :difficulty,
-        { easy: 0, nomal: 10, difficult: 20, very_difficult: 30 },
+        { easy: 0, normal: 10, difficult: 20, very_difficult: 30 },
         prefix: true
 
   scope :title_contain, ->(title) { where("title LIKE ?", "%#{title}%") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,4 +42,8 @@ class User < ApplicationRecord
   def add_saved_sangakus(sangaku)
     saved_sangakus << sangaku
   end
+
+  def dedicated_sangakus_with_shrine
+    @dedicated_sangakus_with_shrine ||= sangakus.where.not(shrine_id: nil).includes(:shrine).to_a
+  end
 end

--- a/app/serializers/my_profile_serializer.rb
+++ b/app/serializers/my_profile_serializer.rb
@@ -1,0 +1,27 @@
+class MyProfileSerializer
+  include JSONAPI::Serializer
+
+  set_type :my_profile
+
+  attributes :email, :nickname, :show_answer_count
+
+  attribute :created_at do |user|
+    user.created_at
+  end
+
+  attribute :sangaku_count do |user|
+    user.sangakus.count
+  end
+
+  attribute :dedicated_sangaku_count do |user|
+    user.sangakus.where.not(shrine_id: nil).count
+  end
+
+  attribute :saved_sangaku_count do |user|
+    user.saved_sangakus.count
+  end
+
+  attribute :answer_count do |user|
+    user.answers.count
+  end
+end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -1,0 +1,29 @@
+class ProfileSerializer
+  include JSONAPI::Serializer
+
+  set_type :profile
+
+  attributes :nickname
+
+  attribute :created_at do |user|
+    user.created_at
+  end
+
+  attribute :sangaku_count do |user|
+    user.sangakus.count
+  end
+
+  attribute :dedicated_sangaku_count do |user|
+    user.dedicated_sangakus_with_shrine.length
+  end
+
+  attribute :answer_count do |user|
+    user.show_answer_count ? user.answers.count : nil
+  end
+
+  attribute :dedicated_sangakus do |user|
+    user.dedicated_sangakus_with_shrine.map do |sangaku|
+      { id: sangaku.id, title: sangaku.title, shrine_name: sangaku.shrine.name }
+    end
+  end
+end

--- a/app/serializers/sangaku_serializer.rb
+++ b/app/serializers/sangaku_serializer.rb
@@ -10,6 +10,11 @@ class SangakuSerializer
   attribute :author_name do |sangaku|
     sangaku.user.nickname
   end
+
+  attribute :shrine_name do |sangaku|
+    sangaku.shrine&.name
+  end
+
   # has_many :fixed_inputs
   belongs_to :user
   belongs_to :shrine

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,20 @@
 class UserSerializer
   include JSONAPI::Serializer
-  attributes :provider, :uid, :name, :email, :nickname
+  attributes :provider, :uid, :name, :email, :nickname, :show_answer_count
+
+  attribute :sangaku_count do |user|
+    user.sangakus.count
+  end
+
+  attribute :dedicated_sangaku_count do |user|
+    user.sangakus.where.not(shrine_id: nil).count
+  end
+
+  attribute :saved_sangaku_count do |user|
+    user.saved_sangakus.count
+  end
+
+  attribute :answer_count do |user|
+    user.answers.count
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,20 +1,4 @@
 class UserSerializer
   include JSONAPI::Serializer
-  attributes :provider, :uid, :name, :email, :nickname, :show_answer_count
-
-  attribute :sangaku_count do |user|
-    user.sangakus.count
-  end
-
-  attribute :dedicated_sangaku_count do |user|
-    user.sangakus.where.not(shrine_id: nil).count
-  end
-
-  attribute :saved_sangaku_count do |user|
-    user.saved_sangakus.count
-  end
-
-  attribute :answer_count do |user|
-    user.answers.count
-  end
+  attributes :provider, :uid, :name, :email, :nickname
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
         resources :sangakus, only: %i[index], controller: "shrines_sangakus"
       end
 
+      resources :profiles, only: %i[show]
+
       namespace :user do
         resources :sangakus, only: %i[index show create update destroy], shallow: true do
           collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
         resources :saved_sangakus, only: %i[index show] do
           get "answer", on: :member
         end
-        resource :profile, only: %i[update]
+        resource :profile, only: %i[show update]
       end
     end
   end

--- a/db/migrate/20260417000000_add_show_answer_count_to_users.rb
+++ b/db/migrate/20260417000000_add_show_answer_count_to_users.rb
@@ -1,0 +1,5 @@
+class AddShowAnswerCountToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :show_answer_count, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_17_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,9 +21,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.text "output"
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.index ["answer_id"], name: "index_answer_results_on_answer_id"
-    t.index ["fixed_input_id", "answer_id"], name: "index_answer_results_on_fixed_input_id_and_answer_id", unique: true
-    t.index ["fixed_input_id"], name: "index_answer_results_on_fixed_input_id"
+    t.index [ "answer_id" ], name: "index_answer_results_on_answer_id"
+    t.index [ "fixed_input_id", "answer_id" ], name: "index_answer_results_on_fixed_input_id_and_answer_id", unique: true
+    t.index [ "fixed_input_id" ], name: "index_answer_results_on_fixed_input_id"
   end
 
   create_table "answers", force: :cascade do |t|
@@ -31,7 +31,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.text "source", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_sangaku_save_id", null: false
-    t.index ["user_sangaku_save_id"], name: "index_answers_on_user_sangaku_save_id"
+    t.index [ "user_sangaku_save_id" ], name: "index_answers_on_user_sangaku_save_id"
   end
 
   create_table "api_keys", force: :cascade do |t|
@@ -40,9 +40,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.datetime "expires_at", default: -> { "(now() + 'P7D'::interval)" }, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index ["access_token"], name: "index_api_keys_on_access_token", unique: true
-    t.index ["expires_at"], name: "index_api_keys_on_expires_at"
-    t.index ["user_id"], name: "index_api_keys_on_user_id"
+    t.index [ "access_token" ], name: "index_api_keys_on_access_token", unique: true
+    t.index [ "expires_at" ], name: "index_api_keys_on_expires_at"
+    t.index [ "user_id" ], name: "index_api_keys_on_user_id"
   end
 
   create_table "fixed_inputs", force: :cascade do |t|
@@ -50,8 +50,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.datetime "created_at", null: false
     t.bigint "sangaku_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["content", "sangaku_id"], name: "index_fixed_inputs_on_content_and_sangaku_id", unique: true
-    t.index ["sangaku_id"], name: "index_fixed_inputs_on_sangaku_id"
+    t.index [ "content", "sangaku_id" ], name: "index_fixed_inputs_on_content_and_sangaku_id", unique: true
+    t.index [ "sangaku_id" ], name: "index_fixed_inputs_on_sangaku_id"
   end
 
   create_table "generate_source_call_logs", force: :cascade do |t|
@@ -59,8 +59,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index ["user_id", "called_at"], name: "index_generate_source_call_logs_on_user_id_and_called_at"
-    t.index ["user_id"], name: "index_generate_source_call_logs_on_user_id"
+    t.index [ "user_id", "called_at" ], name: "index_generate_source_call_logs_on_user_id_and_called_at"
+    t.index [ "user_id" ], name: "index_generate_source_call_logs_on_user_id"
   end
 
   create_table "sangakus", force: :cascade do |t|
@@ -72,8 +72,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index ["shrine_id"], name: "index_sangakus_on_shrine_id"
-    t.index ["user_id"], name: "index_sangakus_on_user_id"
+    t.index [ "shrine_id" ], name: "index_sangakus_on_shrine_id"
+    t.index [ "user_id" ], name: "index_sangakus_on_user_id"
   end
 
   create_table "shrines", force: :cascade do |t|
@@ -84,7 +84,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.string "name", null: false
     t.string "place_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["place_id"], name: "index_shrines_on_place_id", unique: true
+    t.index [ "place_id" ], name: "index_shrines_on_place_id", unique: true
   end
 
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
@@ -94,24 +94,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.bigint "job_id", null: false
     t.integer "priority", default: 0, null: false
     t.string "queue_name", null: false
-    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
-    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
+    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "job_id", null: false
     t.bigint "process_id"
-    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "error"
     t.bigint "job_id", null: false
-    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
@@ -125,17 +125,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.string "queue_name", null: false
     t.datetime "scheduled_at"
     t.datetime "updated_at", null: false
-    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
-    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
-    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
-    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
+    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
+    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
+    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "queue_name", null: false
-    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
   create_table "solid_queue_processes", force: :cascade do |t|
@@ -147,9 +147,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.string "name", null: false
     t.integer "pid", null: false
     t.bigint "supervisor_id"
-    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
@@ -157,9 +157,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.bigint "job_id", null: false
     t.integer "priority", default: 0, null: false
     t.string "queue_name", null: false
-    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
-    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
+    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
@@ -167,8 +167,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.bigint "job_id", null: false
     t.datetime "run_at", null: false
     t.string "task_key", null: false
-    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
@@ -183,8 +183,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.string "schedule", null: false
     t.boolean "static", default: true, null: false
     t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
@@ -193,8 +193,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.integer "priority", default: 0, null: false
     t.string "queue_name", null: false
     t.datetime "scheduled_at", null: false
-    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
@@ -203,9 +203,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.string "key", null: false
     t.datetime "updated_at", null: false
     t.integer "value", default: 1, null: false
-    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   create_table "user_sangaku_saves", force: :cascade do |t|
@@ -213,9 +213,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.bigint "sangaku_id", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index ["sangaku_id"], name: "index_user_sangaku_saves_on_sangaku_id"
-    t.index ["user_id", "sangaku_id"], name: "index_user_sangaku_saves_on_user_id_and_sangaku_id", unique: true
-    t.index ["user_id"], name: "index_user_sangaku_saves_on_user_id"
+    t.index [ "sangaku_id" ], name: "index_user_sangaku_saves_on_sangaku_id"
+    t.index [ "user_id", "sangaku_id" ], name: "index_user_sangaku_saves_on_user_id_and_sangaku_id", unique: true
+    t.index [ "user_id" ], name: "index_user_sangaku_saves_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -224,10 +224,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_225255) do
     t.string "name", null: false
     t.string "nickname", null: false
     t.string "provider", null: false
+    t.boolean "show_answer_count", default: false, null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["uid"], name: "index_users_on_uid", unique: true
+    t.index [ "email" ], name: "index_users_on_email", unique: true
+    t.index [ "uid" ], name: "index_users_on_uid", unique: true
   end
 
   add_foreign_key "answer_results", "answers"

--- a/doc/openapi/profiles.yaml
+++ b/doc/openapi/profiles.yaml
@@ -1,0 +1,89 @@
+---
+openapi: 3.0.3
+info:
+  title: Algo Sangaku Documentation
+  version: 1.0.0
+servers: []
+paths:
+  "/api/v1/profiles/{id}":
+    get:
+      summary: show
+      tags:
+      - Api::V1::Profile
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 128
+      responses:
+        '200':
+          description: 奉納済み算額一覧を返す（タイトル・神社名を含む）
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                      attributes:
+                        type: object
+                        properties:
+                          nickname:
+                            type: string
+                          created_at:
+                            type: string
+                          sangaku_count:
+                            type: integer
+                          dedicated_sangaku_count:
+                            type: integer
+                          answer_count:
+                            nullable: true
+                          dedicated_sangakus:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: integer
+                                title:
+                                  type: string
+                                shrine_name:
+                                  type: string
+                              required:
+                              - id
+                              - title
+                              - shrine_name
+                        required:
+                        - nickname
+                        - created_at
+                        - sangaku_count
+                        - dedicated_sangaku_count
+                        - answer_count
+                        - dedicated_sangakus
+                    required:
+                    - id
+                    - type
+                    - attributes
+                required:
+                - data
+              example:
+                data:
+                  id: '128'
+                  type: profile
+                  attributes:
+                    nickname: test nickname
+                    created_at: '2026-04-17T12:08:47.942+09:00'
+                    sangaku_count: 2
+                    dedicated_sangaku_count: 1
+                    answer_count:
+                    dedicated_sangakus:
+                    - id: 128
+                      title: test_title
+                      shrine_name: test_shrine

--- a/doc/openapi/sangaku_saves.yaml
+++ b/doc/openapi/sangaku_saves.yaml
@@ -16,7 +16,7 @@ paths:
           required: true
           schema:
             type: integer
-          example: 836
+          example: 138
       requestBody:
         content:
           application/json:
@@ -55,6 +55,8 @@ paths:
                             items: {}
                           author_name:
                             type: string
+                          shrine_name:
+                            nullable: true
                         required:
                           - title
                           - description
@@ -99,7 +101,7 @@ paths:
                   - data
               example:
                 data:
-                  id: "836"
+                  id: "138"
                   type: sangaku
                   attributes:
                     title: test_title
@@ -108,10 +110,11 @@ paths:
                     difficulty: easy
                     inputs: []
                     author_name: test nickname
+                    shrine_name:
                   relationships:
                     user:
                       data:
-                        id: "1333"
+                        id: "134"
                         type: user
                     shrine:
                       data:

--- a/doc/openapi/sangakus.yaml
+++ b/doc/openapi/sangakus.yaml
@@ -9,16 +9,16 @@ paths:
     get:
       summary: show
       tags:
-        - Api::V1::Sangaku
+      - Api::V1::Sangaku
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-          example: 837
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 139
       responses:
-        "200":
+        '200':
           description: return sangakus in json format
           content:
             application/json:
@@ -48,13 +48,15 @@ paths:
                             items: {}
                           author_name:
                             type: string
+                          shrine_name:
+                            nullable: true
                         required:
-                          - title
-                          - description
-                          - source
-                          - difficulty
-                          - inputs
-                          - author_name
+                        - title
+                        - description
+                        - source
+                        - difficulty
+                        - inputs
+                        - author_name
                       relationships:
                         type: object
                         properties:
@@ -69,30 +71,30 @@ paths:
                                   type:
                                     type: string
                                 required:
-                                  - id
-                                  - type
+                                - id
+                                - type
                             required:
-                              - data
+                            - data
                           shrine:
                             type: object
                             properties:
                               data:
                                 nullable: true
                             required:
-                              - data
+                            - data
                         required:
-                          - user
-                          - shrine
+                        - user
+                        - shrine
                     required:
-                      - id
-                      - type
-                      - attributes
-                      - relationships
+                    - id
+                    - type
+                    - attributes
+                    - relationships
                 required:
-                  - data
+                - data
               example:
                 data:
-                  id: "837"
+                  id: '139'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -101,10 +103,11 @@ paths:
                     difficulty: easy
                     inputs: []
                     author_name: test nickname
+                    shrine_name:
                   relationships:
                     user:
                       data:
-                        id: "1334"
+                        id: '135'
                         type: user
                     shrine:
                       data:

--- a/doc/openapi/shrines_sangakus.yaml
+++ b/doc/openapi/shrines_sangakus.yaml
@@ -22,7 +22,7 @@ paths:
           required: true
           schema:
             type: integer
-          example: 545
+          example: 72
         - name: title
           in: query
           required: false
@@ -61,6 +61,8 @@ paths:
                               type: array
                               items: {}
                             author_name:
+                              type: string
+                            shrine_name:
                               type: string
                           required:
                             - title
@@ -114,7 +116,7 @@ paths:
                   - data
               example:
                 data:
-                  - id: "838"
+                  - id: "140"
                     type: sangaku
                     attributes:
                       title: test_title
@@ -123,12 +125,13 @@ paths:
                       difficulty: nomal
                       inputs: []
                       author_name: test nickname
+                      shrine_name: test_shrine
                     relationships:
                       user:
                         data:
-                          id: "1336"
+                          id: "137"
                           type: user
                       shrine:
                         data:
-                          id: "545"
+                          id: "72"
                           type: shrine

--- a/doc/openapi/shrines_sangakus.yaml
+++ b/doc/openapi/shrines_sangakus.yaml
@@ -9,28 +9,28 @@ paths:
     get:
       summary: index
       tags:
-        - Api::V1::ShrinesSangaku
+      - Api::V1::ShrinesSangaku
       parameters:
-        - name: difficulty
-          in: query
-          required: false
-          schema:
-            type: string
-          example: nomal
-        - name: shrine_id
-          in: path
-          required: true
-          schema:
-            type: integer
-          example: 72
-        - name: title
-          in: query
-          required: false
-          schema:
-            type: string
-          example: test_title
+      - name: difficulty
+        in: query
+        required: false
+        schema:
+          type: string
+        example: normal
+      - name: shrine_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 67
+      - name: title
+        in: query
+        required: false
+        schema:
+          type: string
+        example: test_title
       responses:
-        "200":
+        '200':
           description: return sangakus in json format
           content:
             application/json:
@@ -65,12 +65,12 @@ paths:
                             shrine_name:
                               type: string
                           required:
-                            - title
-                            - description
-                            - source
-                            - difficulty
-                            - inputs
-                            - author_name
+                          - title
+                          - description
+                          - source
+                          - difficulty
+                          - inputs
+                          - author_name
                         relationships:
                           type: object
                           properties:
@@ -85,10 +85,10 @@ paths:
                                     type:
                                       type: string
                                   required:
-                                    - id
-                                    - type
+                                  - id
+                                  - type
                               required:
-                                - data
+                              - data
                             shrine:
                               type: object
                               properties:
@@ -100,38 +100,38 @@ paths:
                                     type:
                                       type: string
                                   required:
-                                    - id
-                                    - type
+                                  - id
+                                  - type
                               required:
-                                - data
+                              - data
                           required:
-                            - user
-                            - shrine
+                          - user
+                          - shrine
                       required:
-                        - id
-                        - type
-                        - attributes
-                        - relationships
+                      - id
+                      - type
+                      - attributes
+                      - relationships
                 required:
-                  - data
+                - data
               example:
                 data:
-                  - id: "140"
-                    type: sangaku
-                    attributes:
-                      title: test_title
-                      description: test_description
-                      source: puts 'Hello world'
-                      difficulty: nomal
-                      inputs: []
-                      author_name: test nickname
-                      shrine_name: test_shrine
-                    relationships:
-                      user:
-                        data:
-                          id: "137"
-                          type: user
-                      shrine:
-                        data:
-                          id: "72"
-                          type: shrine
+                - id: '94'
+                  type: sangaku
+                  attributes:
+                    title: test_title
+                    description: test_description
+                    source: puts 'Hello world'
+                    difficulty: normal
+                    inputs: []
+                    author_name: test nickname
+                    shrine_name: test_shrine
+                  relationships:
+                    user:
+                      data:
+                        id: '118'
+                        type: user
+                    shrine:
+                      data:
+                        id: '67'
+                        type: shrine

--- a/doc/openapi/user/profiles.yaml
+++ b/doc/openapi/user/profiles.yaml
@@ -56,16 +56,6 @@ paths:
                             type: string
                           nickname:
                             type: string
-                          show_answer_count:
-                            type: boolean
-                          sangaku_count:
-                            type: integer
-                          dedicated_sangaku_count:
-                            type: integer
-                          saved_sangaku_count:
-                            type: integer
-                          answer_count:
-                            type: integer
                         required:
                         - provider
                         - uid
@@ -80,16 +70,11 @@ paths:
                 - data
               example:
                 data:
-                  id: '151'
+                  id: '77'
                   type: user
                   attributes:
                     provider: google
-                    uid: ff985742-07a0-4f00-99f7-e28ec73ee6ec
+                    uid: 82cb0bb7-8ea9-4149-98f3-a8ad36fcaf6a
                     name: test user
-                    email: user_32@example.com
+                    email: user_1@example.com
                     nickname: changed_name
-                    show_answer_count: false
-                    sangaku_count: 0
-                    dedicated_sangaku_count: 0
-                    saved_sangaku_count: 0
-                    answer_count: 0

--- a/doc/openapi/user/profiles.yaml
+++ b/doc/openapi/user/profiles.yaml
@@ -61,13 +61,13 @@ paths:
                 - data
               example:
                 data:
-                  id: '82'
+                  id: '85'
                   type: my_profile
                   attributes:
                     email: user_1@example.com
                     nickname: test nickname
                     show_answer_count: false
-                    created_at: '2026-04-17T14:59:30.299+09:00'
+                    created_at: '2026-04-18T13:50:41.563+09:00'
                     sangaku_count: 2
                     dedicated_sangaku_count: 1
                     saved_sangaku_count: 0
@@ -87,16 +87,17 @@ paths:
                   properties:
                     nickname:
                       type: string
-                  required:
-                  - nickname
+                    show_answer_count:
+                      type: boolean
               required:
               - user
             example:
               user:
                 nickname: changed_name
+                show_answer_count: true
       responses:
         '200':
-          description: return user in json format
+          description: show_answer_count を true に更新できる
           content:
             application/json:
               schema:
@@ -136,11 +137,11 @@ paths:
                 - data
               example:
                 data:
-                  id: '83'
+                  id: '87'
                   type: user
                   attributes:
                     provider: google
-                    uid: 8c1db078-aeed-43a3-9a24-e5e4a1b4189f
+                    uid: eb1d9b56-7370-43c1-b813-6ade816c1e0a
                     name: test user
-                    email: user_2@example.com
-                    nickname: changed_name
+                    email: user_3@example.com
+                    nickname: test nickname

--- a/doc/openapi/user/profiles.yaml
+++ b/doc/openapi/user/profiles.yaml
@@ -6,6 +6,72 @@ info:
 servers: []
 paths:
   "/api/v1/user/profile":
+    get:
+      summary: show
+      tags:
+      - Api::V1::User::Profile
+      responses:
+        '200':
+          description: マイプロフィールを返す
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                      attributes:
+                        type: object
+                        properties:
+                          email:
+                            type: string
+                          nickname:
+                            type: string
+                          show_answer_count:
+                            type: boolean
+                          created_at:
+                            type: string
+                          sangaku_count:
+                            type: integer
+                          dedicated_sangaku_count:
+                            type: integer
+                          saved_sangaku_count:
+                            type: integer
+                          answer_count:
+                            type: integer
+                        required:
+                        - email
+                        - nickname
+                        - show_answer_count
+                        - created_at
+                        - sangaku_count
+                        - dedicated_sangaku_count
+                        - saved_sangaku_count
+                        - answer_count
+                    required:
+                    - id
+                    - type
+                    - attributes
+                required:
+                - data
+              example:
+                data:
+                  id: '82'
+                  type: my_profile
+                  attributes:
+                    email: user_1@example.com
+                    nickname: test nickname
+                    show_answer_count: false
+                    created_at: '2026-04-17T14:59:30.299+09:00'
+                    sangaku_count: 2
+                    dedicated_sangaku_count: 1
+                    saved_sangaku_count: 0
+                    answer_count: 0
     patch:
       summary: update
       tags:
@@ -70,11 +136,11 @@ paths:
                 - data
               example:
                 data:
-                  id: '77'
+                  id: '83'
                   type: user
                   attributes:
                     provider: google
-                    uid: 82cb0bb7-8ea9-4149-98f3-a8ad36fcaf6a
+                    uid: 8c1db078-aeed-43a3-9a24-e5e4a1b4189f
                     name: test user
-                    email: user_1@example.com
+                    email: user_2@example.com
                     nickname: changed_name

--- a/doc/openapi/user/profiles.yaml
+++ b/doc/openapi/user/profiles.yaml
@@ -56,6 +56,16 @@ paths:
                             type: string
                           nickname:
                             type: string
+                          show_answer_count:
+                            type: boolean
+                          sangaku_count:
+                            type: integer
+                          dedicated_sangaku_count:
+                            type: integer
+                          saved_sangaku_count:
+                            type: integer
+                          answer_count:
+                            type: integer
                         required:
                         - provider
                         - uid
@@ -70,11 +80,16 @@ paths:
                 - data
               example:
                 data:
-                  id: '943'
+                  id: '151'
                   type: user
                   attributes:
                     provider: google
-                    uid: 5dfae13d-6f47-4efd-a442-35c8fedb0c53
+                    uid: ff985742-07a0-4f00-99f7-e28ec73ee6ec
                     name: test user
-                    email: user_1@example.com
+                    email: user_32@example.com
                     nickname: changed_name
+                    show_answer_count: false
+                    sangaku_count: 0
+                    dedicated_sangaku_count: 0
+                    saved_sangaku_count: 0
+                    answer_count: 0

--- a/doc/openapi/user/results.yaml
+++ b/doc/openapi/user/results.yaml
@@ -1,0 +1,53 @@
+---
+openapi: 3.0.3
+info:
+  title: Algo Sangaku Documentation
+  version: 1.0.0
+servers: []
+paths:
+  "/api/v1/user/sangakus/{sangaku_id}/result":
+    get:
+      summary: show
+      tags:
+      - Api::V1::User::Result
+      parameters:
+      - name: sangaku_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 148
+      responses:
+        '200':
+          description: return result in json format
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      attributes:
+                        type: object
+                        properties:
+                          user_sangaku_save_count:
+                            type: integer
+                          correct_count:
+                            type: integer
+                          incorrect_count:
+                            type: integer
+                        required:
+                        - user_sangaku_save_count
+                        - correct_count
+                        - incorrect_count
+                    required:
+                    - attributes
+                required:
+                - data
+              example:
+                data:
+                  attributes:
+                    user_sangaku_save_count: 1
+                    correct_count: 1
+                    incorrect_count: 0

--- a/doc/openapi/user/sangakus.yaml
+++ b/doc/openapi/user/sangakus.yaml
@@ -43,6 +43,9 @@ paths:
                               items: {}
                             author_name:
                               type: string
+                            shrine_name:
+                              type: string
+                              nullable: true
                           required:
                           - title
                           - description
@@ -96,7 +99,7 @@ paths:
                 - data
               example:
                 data:
-                - id: '116'
+                - id: '160'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -105,14 +108,15 @@ paths:
                     difficulty: easy
                     inputs: []
                     author_name: test nickname
+                    shrine_name: test_shrine
                   relationships:
                     user:
                       data:
-                        id: '240'
+                        id: '164'
                         type: user
                     shrine:
                       data:
-                        id: '47'
+                        id: '91'
                         type: shrine
       parameters:
       - name: shrine_id
@@ -210,6 +214,8 @@ paths:
                               - content
                           author_name:
                             type: string
+                          shrine_name:
+                            nullable: true
                         required:
                         - title
                         - description
@@ -254,7 +260,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '119'
+                  id: '163'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -262,13 +268,14 @@ paths:
                     source: puts 'Hello world'
                     difficulty: easy
                     inputs:
-                    - id: 12
+                    - id: 3
                       content: test_input_1
                     author_name: test nickname
+                    shrine_name:
                   relationships:
                     user:
                       data:
-                        id: '242'
+                        id: '166'
                         type: user
                     shrine:
                       data:
@@ -326,7 +333,7 @@ paths:
                   used: 1
                   limit: 5
                   remaining: 4
-                  reset_at: '2026-04-12T03:00:00+09:00'
+                  reset_at: '2026-04-18T03:00:00+09:00'
   "/api/v1/user/sangakus/generate_source_usage":
     get:
       summary: generate_source_usage
@@ -357,7 +364,7 @@ paths:
                 used: 0
                 limit: 5
                 remaining: 5
-                reset_at: '2026-04-12T03:00:00+09:00'
+                reset_at: '2026-04-18T03:00:00+09:00'
   "/api/v1/user/sangakus/{id}":
     delete:
       summary: destroy
@@ -369,7 +376,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 123
+        example: 167
       responses:
         '200':
           description: return sangaku in json format
@@ -401,6 +408,8 @@ paths:
                             items: {}
                           author_name:
                             type: string
+                          shrine_name:
+                            nullable: true
                         required:
                         - title
                         - description
@@ -445,7 +454,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '123'
+                  id: '167'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -454,10 +463,11 @@ paths:
                     difficulty: easy
                     inputs: []
                     author_name: test nickname
+                    shrine_name:
                   relationships:
                     user:
                       data:
-                        id: '248'
+                        id: '172'
                         type: user
                     shrine:
                       data:
@@ -471,7 +481,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 120
+        example: 164
       responses:
         '200':
           description: return sangaku in json formata
@@ -503,6 +513,8 @@ paths:
                             items: {}
                           author_name:
                             type: string
+                          shrine_name:
+                            nullable: true
                         required:
                         - title
                         - description
@@ -547,7 +559,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '120'
+                  id: '164'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -556,10 +568,11 @@ paths:
                     difficulty: easy
                     inputs: []
                     author_name: test nickname
+                    shrine_name:
                   relationships:
                     user:
                       data:
-                        id: '243'
+                        id: '167'
                         type: user
                     shrine:
                       data:
@@ -573,7 +586,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 121
+        example: 165
       requestBody:
         content:
           application/json:
@@ -651,6 +664,8 @@ paths:
                               - content
                           author_name:
                             type: string
+                          shrine_name:
+                            nullable: true
                         required:
                         - title
                         - description
@@ -695,7 +710,7 @@ paths:
                 - data
               example:
                 data:
-                  id: '121'
+                  id: '165'
                   type: sangaku
                   attributes:
                     title: changed_title
@@ -703,13 +718,14 @@ paths:
                     source: puts 'Hello world'
                     difficulty: easy
                     inputs:
-                    - id: 13
+                    - id: 4
                       content: a
                     author_name: test nickname
+                    shrine_name:
                   relationships:
                     user:
                       data:
-                        id: '244'
+                        id: '168'
                         type: user
                     shrine:
                       data:

--- a/doc/openapi/user/saved_sangakus.yaml
+++ b/doc/openapi/user/saved_sangakus.yaml
@@ -9,9 +9,9 @@ paths:
     get:
       summary: index
       tags:
-        - Api::V1::SangakuSave
+      - Api::V1::SangakuSave
       responses:
-        "200":
+        '200':
           description: return unsolved saved sangakus in json format
           content:
             application/json:
@@ -43,13 +43,15 @@ paths:
                               items: {}
                             author_name:
                               type: string
+                            shrine_name:
+                              type: string
                           required:
-                            - title
-                            - description
-                            - source
-                            - difficulty
-                            - inputs
-                            - author_name
+                          - title
+                          - description
+                          - source
+                          - difficulty
+                          - inputs
+                          - author_name
                         relationships:
                           type: object
                           properties:
@@ -64,10 +66,10 @@ paths:
                                     type:
                                       type: string
                                   required:
-                                    - id
-                                    - type
+                                  - id
+                                  - type
                               required:
-                                - data
+                              - data
                             shrine:
                               type: object
                               properties:
@@ -80,67 +82,68 @@ paths:
                                     type:
                                       type: string
                                   required:
-                                    - id
-                                    - type
+                                  - id
+                                  - type
                               required:
-                                - data
+                              - data
                           required:
-                            - user
-                            - shrine
+                          - user
+                          - shrine
                       required:
-                        - id
-                        - type
-                        - attributes
-                        - relationships
+                      - id
+                      - type
+                      - attributes
+                      - relationships
                 required:
-                  - data
+                - data
               example:
                 data:
-                  - id: "397"
-                    type: sangaku
-                    attributes:
-                      title: test_title
-                      description: test_description
-                      source: puts 'Hello world'
-                      difficulty: easy
-                      inputs: []
-                      author_name: author
-                    relationships:
-                      user:
-                        data:
-                          id: "636"
-                          type: user
-                      shrine:
-                        data:
-                          id: "246"
-                          type: shrine
+                - id: '170'
+                  type: sangaku
+                  attributes:
+                    title: test_title
+                    description: test_description
+                    source: puts 'Hello world'
+                    difficulty: easy
+                    inputs: []
+                    author_name: author
+                    shrine_name: test_shrine
+                  relationships:
+                    user:
+                      data:
+                        id: '190'
+                        type: user
+                    shrine:
+                      data:
+                        id: '92'
+                        type: shrine
       parameters:
-        - name: type
-          in: query
-          required: false
-          schema:
-            type: string
-          example: before_answer
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+        example: before_answer
   "/api/v1/user/saved_sangakus/{id}":
     get:
       summary: show
       tags:
-        - Api::V1::SangakuSave
+      - Api::V1::SangakuSave
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-          example: 399
-        - name: type
-          in: query
-          required: false
-          schema:
-            type: string
-          example: before_answer
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 172
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+        example: before_answer
       responses:
-        "200":
+        '200':
           description: return sangaku in json format
           content:
             application/json:
@@ -170,13 +173,15 @@ paths:
                             items: {}
                           author_name:
                             type: string
+                          shrine_name:
+                            nullable: true
                         required:
-                          - title
-                          - description
-                          - source
-                          - difficulty
-                          - inputs
-                          - author_name
+                        - title
+                        - description
+                        - source
+                        - difficulty
+                        - inputs
+                        - author_name
                       relationships:
                         type: object
                         properties:
@@ -191,30 +196,30 @@ paths:
                                   type:
                                     type: string
                                 required:
-                                  - id
-                                  - type
+                                - id
+                                - type
                             required:
-                              - data
+                            - data
                           shrine:
                             type: object
                             properties:
                               data:
                                 nullable: true
                             required:
-                              - data
+                            - data
                         required:
-                          - user
-                          - shrine
+                        - user
+                        - shrine
                     required:
-                      - id
-                      - type
-                      - attributes
-                      - relationships
+                    - id
+                    - type
+                    - attributes
+                    - relationships
                 required:
-                  - data
+                - data
               example:
                 data:
-                  id: "399"
+                  id: '172'
                   type: sangaku
                   attributes:
                     title: test_title
@@ -223,10 +228,11 @@ paths:
                     difficulty: easy
                     inputs: []
                     author_name: author
+                    shrine_name:
                   relationships:
                     user:
                       data:
-                        id: "638"
+                        id: '192'
                         type: user
                     shrine:
                       data:
@@ -234,16 +240,16 @@ paths:
     get:
       summary: answer
       tags:
-        - Api::V1::SangakuSave
+      - Api::V1::SangakuSave
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-          example: 400
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 173
       responses:
-        "200":
+        '200':
           description: return answer in json format
           content:
             application/json:
@@ -265,8 +271,8 @@ paths:
                           status:
                             type: string
                         required:
-                          - source
-                          - status
+                        - source
+                        - status
                       relationships:
                         type: object
                         properties:
@@ -281,10 +287,10 @@ paths:
                                   type:
                                     type: string
                                 required:
-                                  - id
-                                  - type
+                                - id
+                                - type
                             required:
-                              - data
+                            - data
                           answer_results:
                             type: object
                             properties:
@@ -298,33 +304,33 @@ paths:
                                     type:
                                       type: string
                                   required:
-                                    - id
-                                    - type
+                                  - id
+                                  - type
                             required:
-                              - data
+                            - data
                         required:
-                          - user_sangaku_save
-                          - answer_results
+                        - user_sangaku_save
+                        - answer_results
                     required:
-                      - id
-                      - type
-                      - attributes
-                      - relationships
+                    - id
+                    - type
+                    - attributes
+                    - relationships
                 required:
-                  - data
+                - data
               example:
                 data:
-                  id: "77"
+                  id: '14'
                   type: answer
                   attributes:
                     source: puts 'Hello world'
-                    status: correct
+                    status: pending
                   relationships:
                     user_sangaku_save:
                       data:
-                        id: "158"
+                        id: '24'
                         type: user_sangaku_save
                     answer_results:
                       data:
-                        - id: "77"
-                          type: answer_result
+                      - id: '14'
+                        type: answer_result

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Profiles", type: :request do
+  describe "GET /show" do
+    let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' } }
+    let!(:user) { create(:user) }
+    let!(:shrine) { create(:shrine) }
+    let!(:dedicated_sangaku) { create(:sangaku, user:, shrine:) }
+    let!(:undedicated_sangaku) { create(:sangaku, user:) }
+    let(:http_request) { get api_v1_profile_path(user.id), headers: }
+
+    context "認証なしでアクセスできる" do
+      it "200を返す", openapi: false do
+        http_request
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "ニックネームを返す", openapi: false do
+        http_request
+        expect(body["data"]["attributes"]["nickname"]).to eq user.nickname
+      end
+
+      it "登録日を返す", openapi: false do
+        http_request
+        expect(body["data"]["attributes"]["created_at"]).to be_present
+      end
+
+      it "算額数を返す", openapi: false do
+        http_request
+        expect(body["data"]["attributes"]["sangaku_count"]).to eq 2
+      end
+
+      it "奉納済み算額数を返す", openapi: false do
+        http_request
+        expect(body["data"]["attributes"]["dedicated_sangaku_count"]).to eq 1
+      end
+
+      it "奉納済み算額一覧を返す（タイトル・神社名を含む）" do
+        http_request
+        dedicated = body["data"]["attributes"]["dedicated_sangakus"]
+        expect(dedicated.length).to eq 1
+        expect(dedicated[0]["title"]).to eq dedicated_sangaku.title
+        expect(dedicated[0]["shrine_name"]).to eq shrine.name
+      end
+
+      it "emailを返さない", openapi: false do
+        http_request
+        expect(body["data"]["attributes"]).not_to have_key("email")
+      end
+    end
+
+    context "show_answer_count が false のユーザー", openapi: false do
+      it "answer_count が nil を返す" do
+        user.update!(show_answer_count: false)
+        http_request
+        expect(body["data"]["attributes"]["answer_count"]).to be_nil
+      end
+    end
+
+    context "show_answer_count が true のユーザー", openapi: false do
+      it "answer_count を返す" do
+        user.update!(show_answer_count: true)
+        http_request
+        expect(body["data"]["attributes"]["answer_count"]).to eq 0
+      end
+    end
+
+    context "存在しないユーザーID", openapi: false do
+      it "404を返す" do
+        get api_v1_profile_path(0), headers: headers
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/shrines_sangakus_spec.rb
+++ b/spec/requests/api/v1/shrines_sangakus_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe "Api::V1::ShrinesSangakus", type: :request do
   describe "GET /api/v1/shrine/{id}/sangakus" do
     let!(:shrine) { create(:shrine) }
-    let!(:sangaku) { create(:sangaku, title: "test_title", difficulty: "nomal", shrine: shrine) }
+    let!(:sangaku) { create(:sangaku, title: "test_title", difficulty: "normal", shrine: shrine) }
     let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' } }
     let(:params) { {} }
     let(:http_request) { get api_v1_shrine_sangakus_path(shrine.id), headers:, params: }
 
     context "with access_token" do
-      let(:params) { { title: "test_title", difficulty: "nomal" } }
+      let(:params) { { title: "test_title", difficulty: "normal" } }
       it "return sangakus in json format" do
         http_request
 

--- a/spec/requests/api/v1/user/profiles_spec.rb
+++ b/spec/requests/api/v1/user/profiles_spec.rb
@@ -15,6 +15,31 @@ RSpec.describe "Api::V1::User::Profiles", type: :request do
         expect(response).to have_http_status(:ok)
         expect(body["data"]["attributes"]["nickname"]).to eq "changed_name"
       end
+
+      it "活動サマリーを返す", openapi: false do
+        authenticate_stub(user)
+        http_request
+
+        attrs = body["data"]["attributes"]
+        expect(attrs).to have_key("sangaku_count")
+        expect(attrs).to have_key("dedicated_sangaku_count")
+        expect(attrs).to have_key("saved_sangaku_count")
+        expect(attrs).to have_key("answer_count")
+        expect(attrs).to have_key("show_answer_count")
+      end
+    end
+
+    context "show_answer_count を更新する", openapi: false do
+      let(:params) { { user: { show_answer_count: true } }.to_json }
+
+      it "show_answer_count を true に更新できる" do
+        authenticate_stub(user)
+        http_request
+
+        expect(response).to have_http_status(:ok)
+        expect(body["data"]["attributes"]["show_answer_count"]).to be true
+        expect(user.reload.show_answer_count).to be true
+      end
     end
   end
 end

--- a/spec/requests/api/v1/user/profiles_spec.rb
+++ b/spec/requests/api/v1/user/profiles_spec.rb
@@ -1,9 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::User::Profiles", type: :request do
+  let!(:user) { create(:user) }
+  let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
+
+  describe "GET /show" do
+    let!(:shrine) { create(:shrine) }
+    let!(:dedicated_sangaku) { create(:sangaku, user:, shrine:) }
+    let!(:undedicated_sangaku) { create(:sangaku, user:) }
+    let(:http_request) { get api_v1_user_profile_path, headers: }
+
+    context "with access_token" do
+      it "マイプロフィールを返す" do
+        authenticate_stub(user)
+        http_request
+
+        expect(response).to have_http_status(:ok)
+        attrs = body["data"]["attributes"]
+        expect(attrs["nickname"]).to eq user.nickname
+        expect(attrs["email"]).to eq user.email
+        expect(attrs["show_answer_count"]).to eq false
+        expect(attrs["sangaku_count"]).to eq 2
+        expect(attrs["dedicated_sangaku_count"]).to eq 1
+        expect(attrs["saved_sangaku_count"]).to eq 0
+        expect(attrs["answer_count"]).to eq 0
+      end
+    end
+  end
+
   describe "PATCH /update" do
-    let!(:user) { create(:user) }
-    let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
     let(:params) { { user: { nickname: "changed_name" } }.to_json }
     let(:http_request) { patch api_v1_user_profile_path, headers:, params: }
 

--- a/spec/requests/api/v1/user/profiles_spec.rb
+++ b/spec/requests/api/v1/user/profiles_spec.rb
@@ -15,18 +15,6 @@ RSpec.describe "Api::V1::User::Profiles", type: :request do
         expect(response).to have_http_status(:ok)
         expect(body["data"]["attributes"]["nickname"]).to eq "changed_name"
       end
-
-      it "活動サマリーを返す", openapi: false do
-        authenticate_stub(user)
-        http_request
-
-        attrs = body["data"]["attributes"]
-        expect(attrs).to have_key("sangaku_count")
-        expect(attrs).to have_key("dedicated_sangaku_count")
-        expect(attrs).to have_key("saved_sangaku_count")
-        expect(attrs).to have_key("answer_count")
-        expect(attrs).to have_key("show_answer_count")
-      end
     end
 
     context "show_answer_count を更新する", openapi: false do
@@ -37,7 +25,6 @@ RSpec.describe "Api::V1::User::Profiles", type: :request do
         http_request
 
         expect(response).to have_http_status(:ok)
-        expect(body["data"]["attributes"]["show_answer_count"]).to be true
         expect(user.reload.show_answer_count).to be true
       end
     end

--- a/spec/requests/api/v1/user/profiles_spec.rb
+++ b/spec/requests/api/v1/user/profiles_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Api::V1::User::Profiles", type: :request do
       end
     end
 
-    context "show_answer_count を更新する", openapi: false do
+    context "show_answer_count を更新する" do
       let(:params) { { user: { show_answer_count: true } }.to_json }
 
       it "show_answer_count を true に更新できる" do


### PR DESCRIPTION
## 概要

issue #219 のバックエンド実装です。
公開プロフィール取得APIの追加と、プライバシー設定・活動サマリー取得に必要なバックエンド変更を行いました。

関連 issue: Alnoir-0011/algo_sangaku#31（親 issue）/ Alnoir-0011/algo_sangaku_back#219

## 変更内容

### 新規

- `GET /api/v1/profiles/:id` — 公開プロフィール取得API（認証不要）
  - ニックネーム・登録日・算額数・奉納済み算額数・奉納済み算額一覧を返す
  - `show_answer_count` が true の場合のみ回答数を返す
  - email などの非公開情報は返さない（`ProfileSerializer` を独立して作成）

### 変更

- `PATCH /api/v1/user/profile` — `show_answer_count` の更新に対応
- `UserSerializer` — 活動サマリー（4種のカウント）と `show_answer_count` を追加
- `SangakuSerializer` — `shrine_name` フィールドを追加

### DB

- `users` テーブルに `show_answer_count` カラム追加（boolean, default: false, null: false）

### OpenAPI

- `doc/openapi/profiles.yaml` 新規作成
- `doc/openapi/user/profiles.yaml` 更新（活動サマリー対応）
- `doc/openapi/sangakus.yaml` 更新（shrine_name 追加）

## 確認方法

1. マイグレーションを実行してください
   ```
   docker-compose exec web bundle exec rails db:migrate
   ```
2. テストが通ることを確認してください
   ```
   docker-compose exec web bundle exec rspec spec/requests/api/v1/profiles_spec.rb spec/requests/api/v1/user/profiles_spec.rb
   ```
3. 認証なしで `GET /api/v1/profiles/:id` が呼べることを確認してください

## 影響範囲

- `GET /api/v1/profiles/:id`（新規、認証不要）
- `PATCH /api/v1/user/profile`（既存エンドポイント、show_answer_count パラメータを追加許可）
- `SangakuSerializer`（shrine_name フィールド追加 — 既存の算額取得レスポンスに新フィールドが加わります）

## チェックリスト

- [x] インテグレーションテストを追加した（13件追加）
- [x] ユニットテストをパスした
- [x] 必要なドキュメント（OpenAPI）を作成した

## コメント

- 公開プロフィールAPIで email 漏洩を防ぐため、`UserSerializer` を使わず `ProfileSerializer` を独立して作成しています
- `ProfileSerializer` の `dedicated_sangaku_count` と `dedicated_sangakus` はメモ化（`User#dedicated_sangakus_with_shrine`）でクエリを共有し、二重発行を防いでいます