### PR TITLE
feat: ECS Exec を有効化して本番環境で Rails console に接続できるようにする

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -14,6 +14,7 @@ resource "aws_ecs_task_definition" "main" {
   network_mode             = "bridge"
   requires_compatibilities = ["EC2"]
   execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
 
   # unix socket を nginx と web で共有するためのボリューム
   volume {
@@ -186,11 +187,12 @@ resource "aws_ecs_task_definition" "main" {
 # ECS サービス
 # ============================================================
 resource "aws_ecs_service" "main" {
-  name            = "${var.app_name}-service"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.main.arn
-  desired_count   = 1
-  launch_type     = "EC2"
+  name                   = "${var.app_name}-service"
+  cluster                = aws_ecs_cluster.main.id
+  task_definition        = aws_ecs_task_definition.main.arn
+  desired_count          = 1
+  launch_type            = "EC2"
+  enable_execute_command = true
 
   # 単一 EC2 のためダウンタイムを許容してデプロイ (ASG なし構成の制約)
   deployment_minimum_healthy_percent = 0

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -27,6 +27,43 @@ resource "aws_iam_instance_profile" "ecs_instance" {
 }
 
 # ============================================================
+# ECS タスクロール (ECS Exec / ssmmessages 用)
+# ============================================================
+data "aws_iam_policy_document" "ecs_task_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task" {
+  name               = "${var.app_name}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+}
+
+data "aws_iam_policy_document" "ecs_exec" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_exec" {
+  name   = "${var.app_name}-ecs-exec"
+  role   = aws_iam_role.ecs_task.id
+  policy = data.aws_iam_policy_document.ecs_exec.json
+}
+
+# ============================================================
 # ECS タスク実行ロール
 # ============================================================
 data "aws_iam_policy_document" "ecs_task_execution_assume_role" {


### PR DESCRIPTION
## 概要

本番環境で `rails console` を実行できるよう、ECS Exec を有効化しました。

**変更内容:**
- `iam.tf`: ECS タスクロール（`algo-sangaku-ecs-task-role`）を新規作成し、ECS Exec に必要な `ssmmessages:*` 権限を付与
- `ecs.tf`: タスク定義に `task_role_arn` を追加、ECS サービスに `enable_execute_command = true` を追加

`terraform apply` は適用済みで、現在稼働中のタスクで ECS Exec が有効になっています。

## 確認方法

以下のコマンドで Rails console に接続できます。

```bash
TASK_ID=$(aws ecs list-tasks \
  --cluster algo-sangaku-cluster \
  --region ap-northeast-1 \
  --query 'taskArns[0]' \
  --output text | awk -F/ '{print $NF}')

aws ecs execute-command \
  --cluster algo-sangaku-cluster \
  --task $TASK_ID \
  --container web \
  --interactive \
  --command "bundle exec rails console -e production" \
  --region ap-northeast-1
```

## 影響範囲

- `terraform/iam.tf`: IAM ロール・ポリシーの追加（既存リソースへの影響なし）
- `terraform/ecs.tf`: タスク定義に `task_role_arn` を追加、サービスに `enable_execute_command = true` を追加
- 本番の ECS タスクは再起動済み（`terraform apply` 時に新タスク定義リビジョンへ切り替え）

## チェックリスト

- [ ] siderをパスした
- [ ] インテグレーションテストを追加した
- [ ] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] 必要なドキュメントを作成した

## コメント

`enable_execute_command = true` を設定する際、ECS の仕様として「サービスが参照するタスク定義に `task_role_arn` が必要」という制約があります。`lifecycle { ignore_changes = [task_definition] }` によりサービスが旧リビジョンを参照したままだったため、apply 時に一時的に ignore_changes を外して新リビジョンへ切り替えた後、元に戻しています。