### PR TITLE
fix: GitHub Actions の iam:PassRole に ecs-task-role を追加

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -189,9 +189,12 @@ data "aws_iam_policy_document" "github_actions_deploy" {
   }
 
   statement {
-    effect    = "Allow"
-    actions   = ["iam:PassRole"]
-    resources = [aws_iam_role.ecs_task_execution.arn]
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+    resources = [
+      aws_iam_role.ecs_task_execution.arn,
+      aws_iam_role.ecs_task.arn,
+    ]
   }
 }
 


### PR DESCRIPTION
## 概要

ECS Exec 有効化（#240）で追加した `algo-sangaku-ecs-task-role` を、GitHub Actions のデプロイポリシーの `iam:PassRole` 対象に追加しました。

`RegisterTaskDefinition` 実行時に `task_role_arn` として新しいタスクロールを渡す必要があり、PassRole 権限がないと以下のエラーが発生していました。

```
aws: [ERROR]: An error occurred (AccessDeniedException) when calling the
RegisterTaskDefinition operation: User: .../algo-sangaku-github-actions-role/GitHubActions
is not authorized to perform: iam:PassRole on resource:
arn:aws:iam::289121533934:role/algo-sangaku-ecs-task-role
```

`terraform apply` は適用済みです。

## 確認方法

GitHub Actions の ECS autodeploy ワークフローを再実行し、エラーなく完了することを確認してください。

## 影響範囲

- `terraform/iam.tf`: `github_actions_deploy` ポリシーの `iam:PassRole` リソースに `ecs_task_execution` ロールに加えて `ecs_task` ロールを追加

## チェックリスト

- [ ] siderをパスした
- [ ] インテグレーションテストを追加した
- [ ] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] 必要なドキュメントを作成した