### PR TITLE
fix: 模範解答の API 漏洩と認証失敗時の 500 エラーを修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.24.5)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     byebug (13.0.0)

--- a/app/controllers/api/v1/authenticates_controller.rb
+++ b/app/controllers/api/v1/authenticates_controller.rb
@@ -6,6 +6,8 @@ module Api
 
       def create
           payload = verify_idtoken
+          return render_400(nil, "invalid token") if payload.nil?
+
           user = ::User.find_by(provider: "google", uid: payload["sub"])
 
         if user
@@ -34,11 +36,9 @@ module Api
 
       def verify_idtoken
         google_client_id = ENV["GOOGLE_CLIENT_ID"]
-        begin
-          Google::Auth::IDTokens.verify_oidc(params[:token], aud: google_client_id)
-        rescue StandardError => e
-          render_400(nil, "invalid token")
-        end
+        Google::Auth::IDTokens.verify_oidc(params[:token], aud: google_client_id)
+      rescue StandardError
+        nil
       end
     end
   end

--- a/app/controllers/api/v1/sangakus_controller.rb
+++ b/app/controllers/api/v1/sangakus_controller.rb
@@ -3,7 +3,7 @@ module Api
     class SangakusController < BaseController
       def show
         sangaku = Sangaku.find(params[:id])
-        render json: SangakuSerializer.new(sangaku).serializable_hash.to_json, status: :ok
+        render json: PublicSangakuSerializer.new(sangaku).serializable_hash.to_json, status: :ok
       end
     end
   end

--- a/app/controllers/api/v1/shrines_sangakus_controller.rb
+++ b/app/controllers/api/v1/shrines_sangakus_controller.rb
@@ -6,7 +6,7 @@ module Api
       def index
         shrine = Shrine.find(params[:shrine_id])
         @pagy, sangakus = pagy(shrine.sangakus.search(search_params).includes(:fixed_inputs, :user, :shrine))
-        render json: SangakuSerializer.new(sangakus).serializable_hash.to_json, status: :ok
+        render json: PublicSangakuSerializer.new(sangakus).serializable_hash.to_json, status: :ok
       end
 
       private

--- a/app/controllers/api/v1/user/saved_sangakus_controller.rb
+++ b/app/controllers/api/v1/user/saved_sangakus_controller.rb
@@ -4,23 +4,23 @@ module Api
       def index
         if params[:type] == "answered"
           @pagy, saved_sangakus = pagy(current_user.saved_sangakus.left_joins(:answers).where.not(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user, :shrine))
-          render json: SangakuSerializer.new(saved_sangakus).serializable_hash.to_json
+          render json: PublicSangakuSerializer.new(saved_sangakus).serializable_hash.to_json
         elsif params[:type] == "before_answer"
           @pagy, saved_sangakus = pagy(current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user, :shrine))
-          render json: SangakuSerializer.new(saved_sangakus).serializable_hash.to_json
+          render json: PublicSangakuSerializer.new(saved_sangakus).serializable_hash.to_json
         else
           @pagy, saved_sangakus = pagy(current_user.saved_sangakus.includes(:fixed_inputs, :user, :shrine))
-          render json: SangakuSerializer.new(saved_sangakus).serializable_hash.to_json
+          render json: PublicSangakuSerializer.new(saved_sangakus).serializable_hash.to_json
         end
       end
 
       def show
         if params[:type] == "before_answer"
           saved_sangaku = current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).find(params[:id])
-          render json: SangakuSerializer.new(saved_sangaku).serializable_hash.to_json
+          render json: PublicSangakuSerializer.new(saved_sangaku).serializable_hash.to_json
         else
           saved_sangaku = current_user.saved_sangakus.find(params[:id])
-          render json: SangakuSerializer.new(saved_sangaku).serializable_hash.to_json
+          render json: PublicSangakuSerializer.new(saved_sangaku).serializable_hash.to_json
         end
       end
 

--- a/app/serializers/public_sangaku_serializer.rb
+++ b/app/serializers/public_sangaku_serializer.rb
@@ -1,0 +1,20 @@
+class PublicSangakuSerializer
+  include JSONAPI::Serializer
+
+  set_type :sangaku
+  attributes :title, :description, :difficulty
+  attribute :inputs do |sangaku|
+    inputs = sangaku.fixed_inputs
+    inputs.map { |input| { id: input.id, content: input.content } }
+  end
+  attribute :author_name do |sangaku|
+    sangaku.user.nickname
+  end
+
+  attribute :shrine_name do |sangaku|
+    sangaku.shrine&.name
+  end
+
+  belongs_to :user
+  belongs_to :shrine
+end

--- a/spec/requests/api/v1/authenticates_spec.rb
+++ b/spec/requests/api/v1/authenticates_spec.rb
@@ -9,6 +9,20 @@ RSpec.describe "Api::V1::Authenticates", type: :request do
       allow_any_instance_of(Api::V1::AuthenticatesController).to receive(:verify_idtoken).and_return(dummy_payload)
     end
 
+    context 'with invalid token' do
+      let!(:params) { { token: 'invalid_token' }.to_json }
+      let(:http_request) { post api_v1_authenticate_path, params: params, headers: headers }
+
+      before do
+        allow_any_instance_of(Api::V1::AuthenticatesController).to receive(:verify_idtoken).and_return(nil)
+      end
+
+      it 'returns 400 bad request' do
+        http_request
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
     context 'user not created' do
       let!(:params) { { token: 'dummy_idtoken' }.to_json }
       let!(:user_attr) { attributes_for(:user) }

--- a/spec/requests/api/v1/sangakus_spec.rb
+++ b/spec/requests/api/v1/sangakus_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe "Api::V1::Sangakus", type: :request do
         expect(response).to be_successful
         expect(body["data"]["attributes"]["title"]).to eq sangaku.title
       end
+
+      it "does not include source in response" do
+        authenticate_stub(user)
+
+        http_request
+        expect(body["data"]["attributes"].keys).not_to include("source")
+      end
     end
 
     context "with nonexistent id", openapi: false do

--- a/spec/requests/api/v1/shrines_sangakus_spec.rb
+++ b/spec/requests/api/v1/shrines_sangakus_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe "Api::V1::ShrinesSangakus", type: :request do
         expect(body["data"][0]["id"]).to eq sangaku.id.to_s
         expect(body["data"][0]["attributes"]["title"]).to eq sangaku.title
       end
+
+      it "does not include source in response" do
+        http_request
+
+        expect(body["data"][0]["attributes"].keys).not_to include("source")
+      end
     end
   end
 end

--- a/spec/requests/api/v1/user/saved_sangakus_spec.rb
+++ b/spec/requests/api/v1/user/saved_sangakus_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe "Api::V1::User::SavedSangakus", type: :request, openapi: { tags: 
         expect(body["data"][0]["attributes"]["title"]).to eq sangaku.title
         expect(body["data"][0]["attributes"]["author_name"]).to eq author.nickname
       end
+
+      it "does not include source in response" do
+        authenticate_stub(user)
+        http_request
+
+        expect(body["data"][0]["attributes"].keys).not_to include("source")
+      end
     end
   end
 
@@ -45,6 +52,13 @@ RSpec.describe "Api::V1::User::SavedSangakus", type: :request, openapi: { tags: 
         expect(response).to have_http_status(:ok)
         expect(body["data"]["attributes"]["title"]).to eq sangaku.title
         expect(body["data"]["attributes"]["author_name"]).to eq author.nickname
+      end
+
+      it "does not include source in response" do
+        authenticate_stub(user)
+        http_request
+
+        expect(body["data"]["attributes"].keys).not_to include("source")
       end
     end
   end


### PR DESCRIPTION
## 概要

issue #247 で報告された2件の Blocker バグを修正します。

- **B-1**: `SangakuSerializer` が `source`（模範解答）を含んでいたため、解答者向けエンドポイントから正解コードが取得できてしまう問題
- **B-2**: Google ID トークン検証失敗時に `rescue` ブロックで `render_400` を呼んでも `return` がなく処理が継続し、`NoMethodError` → 500 が発生する問題

Close #247

## 確認方法

1. `docker-compose up` でサービスを起動してください
2. 以下のスペックを実行して全件グリーンを確認してください

```bash
bundle exec rspec spec/requests/api/v1/sangakus_spec.rb \
  spec/requests/api/v1/shrines_sangakus_spec.rb \
  spec/requests/api/v1/authenticates_spec.rb \
  spec/requests/api/v1/user/saved_sangakus_spec.rb
```

## 影響範囲

- **B-1 修正**: 以下3エンドポイントのレスポンスから `source` フィールドが除外されます
  - `GET /api/v1/sangakus/:id`
  - `GET /api/v1/shrines/:shrine_id/sangakus`
  - `GET /api/v1/user/saved_sangakus`（index / show）
- **B-1 非影響**: 出題者向け `GET /api/v1/user/sangakus` は従来通り `SangakuSerializer` を使用し `source` を返します
- **B-2 修正**: `POST /api/v1/authenticate` で無効・期限切れトークンを渡した場合、500 ではなく 400 が返ります

## チェックリスト

- [x] インテグレーションテストを追加した
- [x] ユニットテストをパスした

## コメント

- B-1: `PublicSangakuSerializer` を `SangakuSerializer` から `source` を除いて新規作成。フロントエンド側の型定義には影響があるが、解答者向けページで `source` を参照している箇所はないため別途対応。
- B-2: `verify_idtoken` は検証結果を返すだけのメソッドに変更し、`nil` チェック + `return` を `create` 側に追加。