### PR TITLE
docs: PR #250 で漏れていた OpenAPI ドキュメントを更新

### DIFF
--- a/doc/openapi/authenticates.yaml
+++ b/doc/openapi/authenticates.yaml
@@ -90,3 +90,16 @@ paths:
                     name: test user
                     email: user_2@example.com
                     nickname: test nickname
+        "400":
+          description: invalid or expired token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+              example:
+                message: invalid token

--- a/doc/openapi/sangakus.yaml
+++ b/doc/openapi/sangakus.yaml
@@ -39,8 +39,6 @@ paths:
                             type: string
                           description:
                             type: string
-                          source:
-                            type: string
                           difficulty:
                             type: string
                           inputs:
@@ -53,7 +51,6 @@ paths:
                         required:
                         - title
                         - description
-                        - source
                         - difficulty
                         - inputs
                         - author_name
@@ -99,7 +96,6 @@ paths:
                   attributes:
                     title: test_title
                     description: test_description
-                    source: puts 'Hello world'
                     difficulty: easy
                     inputs: []
                     author_name: test nickname

--- a/doc/openapi/shrines_sangakus.yaml
+++ b/doc/openapi/shrines_sangakus.yaml
@@ -53,8 +53,6 @@ paths:
                               type: string
                             description:
                               type: string
-                            source:
-                              type: string
                             difficulty:
                               type: string
                             inputs:
@@ -67,7 +65,6 @@ paths:
                           required:
                           - title
                           - description
-                          - source
                           - difficulty
                           - inputs
                           - author_name
@@ -121,7 +118,6 @@ paths:
                   attributes:
                     title: test_title
                     description: test_description
-                    source: puts 'Hello world'
                     difficulty: normal
                     inputs: []
                     author_name: test nickname

--- a/doc/openapi/user/saved_sangakus.yaml
+++ b/doc/openapi/user/saved_sangakus.yaml
@@ -34,8 +34,6 @@ paths:
                               type: string
                             description:
                               type: string
-                            source:
-                              type: string
                             difficulty:
                               type: string
                             inputs:
@@ -48,7 +46,6 @@ paths:
                           required:
                           - title
                           - description
-                          - source
                           - difficulty
                           - inputs
                           - author_name
@@ -103,7 +100,6 @@ paths:
                   attributes:
                     title: test_title
                     description: test_description
-                    source: puts 'Hello world'
                     difficulty: easy
                     inputs: []
                     author_name: author
@@ -164,8 +160,6 @@ paths:
                             type: string
                           description:
                             type: string
-                          source:
-                            type: string
                           difficulty:
                             type: string
                           inputs:
@@ -178,7 +172,6 @@ paths:
                         required:
                         - title
                         - description
-                        - source
                         - difficulty
                         - inputs
                         - author_name
@@ -224,7 +217,6 @@ paths:
                   attributes:
                     title: test_title
                     description: test_description
-                    source: puts 'Hello world'
                     difficulty: easy
                     inputs: []
                     author_name: author


### PR DESCRIPTION
## 概要

PR #250（fix: 模範解答の API 漏洩と認証失敗時の 500 エラーを修正）で更新されたエンドポイントの OpenAPI ドキュメントが更新されていなかったため、本 PR で補完します。

Close #247 関連（ドキュメント補完）

## 確認方法

各 YAML ファイルの diff を確認してください。

## 影響範囲

- `doc/openapi/sangakus.yaml` — `GET /api/v1/sangakus/:id` のレスポンスから `source` フィールドを削除
- `doc/openapi/shrines_sangakus.yaml` — `GET /api/v1/shrines/:shrine_id/sangakus` のレスポンスから `source` フィールドを削除
- `doc/openapi/user/saved_sangakus.yaml` — `GET /api/v1/user/saved_sangakus`（index / show）のレスポンスから `source` フィールドを削除
- `doc/openapi/authenticates.yaml` — `POST /api/v1/authenticate` に `400`（invalid or expired token）レスポンスを追加

## チェックリスト

- [ ] siderをパスした
- [x] インテグレーションテストを追加した（PR #250 側で対応済み）
- [ ] Lint のチェックをパスした
- [x] ユニットテストをパスした（PR #250 側で対応済み）
- [x] 必要なドキュメントを作成した

## コメント

ドキュメントのみの変更です。実装コードへの影響はありません。