### PR TITLE
fix: 採点機能の堅牢性・API設計・テスト基盤の改善 (issue #248)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Run rspec
         run: bundle exec rspec
+        env:
+          COVERAGE: true
 
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+# Ignore SimpleCov coverage reports (generated artifact).
+/coverage/
+
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "googleauth", "~> 1.17"
 
 gem "solid_queue", "~> 1.4"
 gem "ruby-openai", "~> 8.3"
+gem "rack-attack", "~> 6.7"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -62,4 +63,5 @@ end
 
 group :test do
   gem "rspec-openapi"
+  gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       reline (>= 0.3.8)
     deep_merge (1.2.2)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -176,6 +177,7 @@ GEM
     marcel (1.1.0)
     method_source (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -203,6 +205,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.3-aarch64-linux-musl)
@@ -266,6 +271,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (3.0.0)
       logger
       rack (>= 3.0.14)
@@ -378,6 +385,12 @@ GEM
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     solid_queue (1.4.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
@@ -419,6 +432,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
+  ruby
   x86_64-darwin
   x86_64-linux
   x86_64-linux-gnu
@@ -441,6 +455,7 @@ DEPENDENCIES
   pry-doc (~> 1.7)
   pry-rails (~> 0.3.11)
   puma (>= 5.0)
+  rack-attack (~> 6.7)
   rack-cors (~> 3.0)
   rails (~> 8.1.3)
   rails-i18n
@@ -448,6 +463,7 @@ DEPENDENCIES
   rspec-rails (~> 8.0)
   rubocop-rails-omakase
   ruby-openai (~> 8.3)
+  simplecov
   solid_queue (~> 1.4)
   tzinfo-data
   webmock (~> 3.26)

--- a/app/controllers/api/v1/user/answers_controller.rb
+++ b/app/controllers/api/v1/user/answers_controller.rb
@@ -3,6 +3,11 @@ module Api
     class User::AnswersController < BaseController
       def create
         sangaku_save = current_user.user_sangaku_saves.find_by!(sangaku_id: params[:sangaku_id])
+
+        if sangaku_save.answer.present?
+          return render_error(409, "Conflict", "この算額にはすでに解答が存在します")
+        end
+
         answer = sangaku_save.build_answer(answer_params)
 
         if answer.save

--- a/app/controllers/api/v1/user/results_controller.rb
+++ b/app/controllers/api/v1/user/results_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class User::ResultsController < BaseController
       def show
-        sangaku = current_user.sangakus.find_by(id: params[:sangaku_id])
+        sangaku = current_user.sangakus.find(params[:sangaku_id])
 
         user_sangaku_save_count = sangaku.user_sangaku_saves.count
         correct_count = sangaku.answers.is_status("correct").count

--- a/app/controllers/concerns/api/exception_handler.rb
+++ b/app/controllers/concerns/api/exception_handler.rb
@@ -5,6 +5,7 @@ module Api::ExceptionHandler
     rescue_from StandardError, with: :render_500
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
     rescue_from ActionController::ParameterMissing, with: :render_400
+    rescue_from ActiveRecord::RecordNotUnique, with: :render_409
   end
 
   private
@@ -20,6 +21,10 @@ module Api::ExceptionHandler
 
   def render_404(exception = nil, messages = nil)
     render_error(404, "Record Not Found")
+  end
+
+  def render_409(exception = nil, messages = nil)
+    render_error(409, "Conflict")
   end
 
   def render_error(code, message, *error_messages)

--- a/app/jobs/correctness_check_job.rb
+++ b/app/jobs/correctness_check_job.rb
@@ -1,9 +1,13 @@
 class CorrectnessCheckJob < ApplicationJob
   queue_as :default
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   def perform(answer_result)
     return unless answer_result.status_pending?
 
     answer_result.update_status
+  rescue StandardError
+    answer_result.update(status: :error) if executions >= 3
+    raise
   end
 end

--- a/app/models/answer_result.rb
+++ b/app/models/answer_result.rb
@@ -9,21 +9,21 @@ class AnswerResult < ApplicationRecord
   validates :output, length: { maximum: 65_535 }
   validates :fixed_input_id, uniqueness: { scope: :answer_id }
 
-  enum :status, { pending: 0, correct: 10, incorrect: 20 }, prefix: true
+  enum :status, { pending: 0, correct: 10, incorrect: 20, error: 30 }, prefix: true
 
   def update_status
     source = answer.source
-    sangaku_source = answer.user_sangaku_save.sangaku.source
     input = fixed_input ? fixed_input.content : ""
 
     answer_result = run_source(source, input)
-    correct_result = run_source(sangaku_source, input)
+
+    correct_stdout = cached_expected_output(input)
 
     new_status = "pending"
     output = ""
 
     if answer_result["stderror"].blank?
-      new_status =  answer_result["stdout"] == correct_result["stdout"] ? "correct" : "incorrect"
+      new_status = answer_result["stdout"] == correct_stdout ? "correct" : "incorrect"
       output = answer_result["stdout"]
     else
       new_status = "incorrect"
@@ -34,6 +34,15 @@ class AnswerResult < ApplicationRecord
   end
 
   private
+
+  def cached_expected_output(input)
+    if fixed_input&.expected_output.present?
+      fixed_input.expected_output
+    else
+      sangaku_source = answer.user_sangaku_save.sangaku.source
+      run_source(sangaku_source, input)["stdout"]
+    end
+  end
 
   def check_later
     CorrectnessCheckJob.perform_later(self)

--- a/app/models/concerns/paizaio_api.rb
+++ b/app/models/concerns/paizaio_api.rb
@@ -1,17 +1,22 @@
 module PaizaioApi
   extend ActiveSupport::Concern
 
+  MAX_POLL_ATTEMPTS = 30
+
   def run_source(source, input = "", language = "ruby")
     id = create(source, language, input)
     status = "running"
+    attempts = 0
 
     while status == "running"
+      raise StandardError, "PaizaIO polling timeout" if attempts >= MAX_POLL_ATTEMPTS
+
       sleep(100.0 / 1000.0)
       status = get_status(id)
+      attempts += 1
     end
 
-    result = get_details(id)
-    result
+    get_details(id)
   end
 
   def create(source, language, input)
@@ -19,6 +24,8 @@ module PaizaioApi
     uri = URI(api_url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme === "https"
+    http.open_timeout = 10
+    http.read_timeout = 30
 
     headers = { "Content-Type" => "application/json" }
     params = {

--- a/app/models/fixed_input.rb
+++ b/app/models/fixed_input.rb
@@ -1,8 +1,21 @@
 class FixedInput < ApplicationRecord
+  include PaizaioApi
+
   belongs_to :sangaku
 
   has_many :answer_results
 
   validates :content, presence: true, length: { maximum: 65_535 }
   validates :content, uniqueness: { scope: :sangaku_id }
+
+  after_commit :generate_expected_output, on: %i[create update]
+
+  private
+
+  def generate_expected_output
+    result = run_source(sangaku.source, content)
+    update_columns(expected_output: result["stdout"])
+  rescue StandardError
+    # PaizaIO 失敗時は nil のまま。採点時に都度実行するフォールバックに任せる
+  end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,5 @@
+class Rack::Attack
+  throttle("api/ip", limit: 60, period: 1.minute) do |req|
+    req.ip if req.path.start_with?("/api/")
+  end
+end

--- a/db/migrate/20260614000001_add_expected_output_to_fixed_inputs.rb
+++ b/db/migrate/20260614000001_add_expected_output_to_fixed_inputs.rb
@@ -1,0 +1,5 @@
+class AddExpectedOutputToFixedInputs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :fixed_inputs, :expected_output, :text
+  end
+end

--- a/db/migrate/20260614000002_add_unique_index_to_answers.rb
+++ b/db/migrate/20260614000002_add_unique_index_to_answers.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToAnswers < ActiveRecord::Migration[8.1]
+  def change
+    add_index :answers, :user_sangaku_save_id, unique: true, name: "index_answers_on_user_sangaku_save_id_unique"
+    remove_index :answers, name: "index_answers_on_user_sangaku_save_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -31,7 +31,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
     t.text "source", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_sangaku_save_id", null: false
-    t.index [ "user_sangaku_save_id" ], name: "index_answers_on_user_sangaku_save_id"
+    t.index [ "user_sangaku_save_id" ], name: "index_answers_on_user_sangaku_save_id_unique", unique: true
   end
 
   create_table "api_keys", force: :cascade do |t|
@@ -48,6 +48,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
   create_table "fixed_inputs", force: :cascade do |t|
     t.text "content", null: false
     t.datetime "created_at", null: false
+    t.text "expected_output"
     t.bigint "sangaku_id", null: false
     t.datetime "updated_at", null: false
     t.index [ "content", "sangaku_id" ], name: "index_fixed_inputs_on_content_and_sangaku_id", unique: true

--- a/spec/jobs/correctness_check_job_spec.rb
+++ b/spec/jobs/correctness_check_job_spec.rb
@@ -17,13 +17,12 @@ RSpec.describe CorrectnessCheckJob, type: :job do
     end
 
     it 'sets status to error after exhausting retries' do
-      allow(answer_result).to receive(:update_status).and_raise(StandardError, "PaizaIO error")
-      allow_any_instance_of(CorrectnessCheckJob).to receive(:executions).and_return(3)
+      allow_any_instance_of(AnswerResult).to receive(:update_status).and_raise(StandardError, "PaizaIO error")
 
-      expect {
-        CorrectnessCheckJob.perform_now(answer_result)
-      }.to raise_error(StandardError)
+      job = CorrectnessCheckJob.new
+      allow(job).to receive(:executions).and_return(3)
 
+      expect { job.perform(answer_result) }.to raise_error(StandardError)
       expect(answer_result.reload.status).to eq("error")
     end
   end

--- a/spec/jobs/correctness_check_job_spec.rb
+++ b/spec/jobs/correctness_check_job_spec.rb
@@ -1,25 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe CorrectnessCheckJob, type: :job do
-  # let!(:user) { create(:user) }
-  # let!(:author) { create(:user, nickname: "author") }
-  # let!(:shrine) { create(:shrine) }
-  # let!(:sangaku) { create(:sangaku, shrine:, user: author) }
-  # let!(:user_sangaku_save) { create(:user_sangaku_save, user:, sangaku:) }
   let!(:answer_result) { create(:answer_result, output: nil, status: "pending") }
 
-  describe 'perform_later' do
-    it 'enqueue job' do
+  describe '#perform' do
+    it 'enqueues the job' do
       ActiveJob::Base.queue_adapter = :test
       CorrectnessCheckJob.perform_later(answer_result)
       expect(CorrectnessCheckJob).to have_been_enqueued
     end
 
-    it 'check answer' do
-      ActiveJob::Base.queue_adapter = :test
+    it 'updates output and status to correct when answer matches expected' do
+      CorrectnessCheckJob.perform_now(answer_result)
+      expect(answer_result.reload.output).to eq("Hello world\n")
+      expect(answer_result.reload.status).to eq("correct")
+    end
+
+    it 'sets status to error after exhausting retries' do
+      allow(answer_result).to receive(:update_status).and_raise(StandardError, "PaizaIO error")
+      allow_any_instance_of(CorrectnessCheckJob).to receive(:executions).and_return(3)
+
       expect {
         CorrectnessCheckJob.perform_now(answer_result)
-      }.to change { answer_result.output }.from(nil).to("Hello world\n")
+      }.to raise_error(StandardError)
+
+      expect(answer_result.reload.status).to eq("error")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'simplecov'
+SimpleCov.start 'rails' do
+  minimum_coverage 80
+  add_filter '/spec/'
+  add_filter '/config/'
+  add_filter '/db/'
+end
+
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
@@ -12,8 +20,8 @@ require 'rspec/rails'
 Dir[Rails.root.join('spec/support/*.rb')].sort.each { |f| require f }
 Dir[Rails.root.join('spec/support/example/*.rb')].sort.each { |f| require f }
 # enable gem "webmock"
-require 'webmock'
-WebMock.allow_net_connect!(net_http_connect_on_start: true)
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
 
 require 'rspec_openapi'
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -77,4 +85,9 @@ RSpec.configure do |config|
   config.include ResponseHelper
   config.include AuthenticationHelper
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include PaizaioStubs
+
+  config.before(:each) do
+    stub_paizaio_api
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'simplecov'
 SimpleCov.start 'rails' do
-  minimum_coverage 80
+  minimum_coverage 80 if ENV['COVERAGE']
   add_filter '/spec/'
   add_filter '/config/'
   add_filter '/db/'

--- a/spec/support/paizaio_stubs.rb
+++ b/spec/support/paizaio_stubs.rb
@@ -1,0 +1,24 @@
+module PaizaioStubs
+  def stub_paizaio_api(stdout: "Hello world\n")
+    stub_request(:post, "https://api.paiza.io/runners/create.json")
+      .to_return(
+        status: 200,
+        body: { id: "test_runner_id" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    stub_request(:get, /api\.paiza\.io.*get_status/)
+      .to_return(
+        status: 200,
+        body: { status: "completed" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    stub_request(:get, /api\.paiza\.io.*get_details/)
+      .to_return(
+        status: 200,
+        body: { stdout: stdout, stderror: "" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+end


### PR DESCRIPTION
## 概要

コードレビュー（2026-06-13）で発見された Major 問題 9件（M-1〜M-9）を修正。

関連 issue: #248

| M | 対象 | 対応内容 |
|---|------|---------|
| M-1 | `paizaio_api.rb` | ポーリング最大30回上限 + `open_timeout`/`read_timeout` 設定 |
| M-2 | `correctness_check_job.rb` / `answer_result.rb` | `retry_on` 3回 + 最終失敗時に `status: :error` へ更新 |
| M-3 | `fixed_inputs` / `answer_result.rb` | `expected_output` カラム追加。算額作成時に模範解答をキャッシュし採点時の PaizaIO 呼び出しを1回に削減 |
| M-4 | `user/results_controller.rb` | `find_by` → `find` に変更。nil 時に 500 ではなく 404 を返す |
| M-5 | `answers` / `user/answers_controller.rb` | `user_sangaku_save_id` に unique index 追加。重複提出時に 409 を返す |
| M-6 | `exception_handler.rb` | `ActiveRecord::RecordNotUnique` を rescue して 409 を返す |
| M-7 | `rack_attack.rb` | Rack::Attack 導入。IP 毎 60req/1min でスロットリング |
| M-8 | `Gemfile` / `rails_helper.rb` / `ci.yml` | SimpleCov 導入。CI で `minimum_coverage 80` を enforce |
| M-9 | `rails_helper.rb` / `correctness_check_job_spec.rb` | `WebMock.disable_net_connect!` に変更。PaizaIO を `stub_request` でモック化 |

## 確認方法

1. `bundle install` を実行してください（rack-attack / simplecov を追加）
2. `bundle exec rails db:migrate RAILS_ENV=test` を実行してください（2件のマイグレーション）
3. `bundle exec rspec` でテストが全件グリーンになることを確認してください

## 影響範囲

- `FixedInput` 作成・更新時に PaizaIO を呼ぶ `after_commit` フックを追加。テスト環境は `spec/support/paizaio_stubs.rb` でスタブ済み
- `AnswerResult#status` enum に `error: 30` を追加。既存の `pending/correct/incorrect` との後方互換性あり
- `answers` テーブルへの unique index 追加はマイグレーション要
- WebMock を `disable_net_connect!` に変更したため、外部 API を使う既存テストがあれば追加スタブが必要になる

## チェックリスト

- [ ] `bundle exec rspec` がグリーン
- [ ] `bin/rubocop` がパス
- [ ] `bin/brakeman` がパス
- [ ] マイグレーション実行済み（`db/migrate/20260614000001`, `20260614000002`）

## コメント

- M-3 の既存 `FixedInput` レコードの `expected_output` は NULL のまま。`nil` の場合は従来通り PaizaIO で都度実行するフォールバック動作になっています
- M-9 の `WebMock.disable_net_connect!` への変更により、他テストファイルでも外部 API を叩いているものがあれば `stub_request` の追加が必要になる可能性があります