### PR TITLE
[BE] admin ユーザー検索・登録日時ソートを実装（issue #252）

### DIFF
--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -5,7 +5,7 @@ module Api
         before_action :set_user, only: %i[show update]
 
         def index
-          @pagy, users = pagy(::User.all)
+          @pagy, users = pagy(filtered_users.order(created_at: sort_direction))
           render json: ::Admin::UserSerializer.new(users).serializable_hash.to_json, status: :ok
         end
 
@@ -42,6 +42,18 @@ module Api
 
         def set_user
           @user = ::User.find(params[:id])
+        end
+
+        ALLOWED_SORT_DIRECTIONS = %w[asc desc].freeze
+
+        def filtered_users
+          return ::User.all unless params[:query].present?
+
+          ::User.search(params[:query].to_s)
+        end
+
+        def sort_direction
+          ALLOWED_SORT_DIRECTIONS.include?(params[:sort]) ? params[:sort].to_sym : :desc
         end
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,11 @@ class User < ApplicationRecord
 
   enum :role, { general: 0, admin: 1 }
 
+  scope :search, ->(query) {
+    q = "%#{sanitize_sql_like(query)}%"
+    where("email ILIKE ? OR nickname ILIKE ?", q, q)
+  }
+
   GENERATE_SOURCE_DAILY_LIMIT_DEFAULT = 5
 
   def generate_source_daily_limit

--- a/doc/openapi/admin/users.yaml
+++ b/doc/openapi/admin/users.yaml
@@ -10,6 +10,32 @@ paths:
       summary: index
       tags:
       - Api::V1::Admin::User
+      parameters:
+      - name: query
+        in: query
+        required: false
+        description: email または nickname に対する部分一致検索（大文字小文字無視）
+        schema:
+          type: string
+        example: example
+      - name: sort
+        in: query
+        required: false
+        description: 登録日時（created_at）のソート順。未指定時は desc（降順）
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: desc
+        example: desc
+      - name: page
+        in: query
+        required: false
+        description: ページ番号
+        schema:
+          type: integer
+        example: 1
       responses:
         '200':
           description: returns 200 with users list

--- a/doc/openapi/admin/users.yaml
+++ b/doc/openapi/admin/users.yaml
@@ -10,35 +10,9 @@ paths:
       summary: index
       tags:
       - Api::V1::Admin::User
-      parameters:
-      - name: query
-        in: query
-        required: false
-        description: email または nickname に対する部分一致検索（大文字小文字無視）
-        schema:
-          type: string
-        example: example
-      - name: sort
-        in: query
-        required: false
-        description: 登録日時（created_at）のソート順。未指定時は desc（降順）
-        schema:
-          type: string
-          enum:
-          - asc
-          - desc
-          default: desc
-        example: desc
-      - name: page
-        in: query
-        required: false
-        description: ページ番号
-        schema:
-          type: integer
-        example: 1
       responses:
         '200':
-          description: returns 200 with users list
+          description: returns users in descending order when sort=desc
           content:
             application/json:
               schema:
@@ -86,24 +60,44 @@ paths:
                 - data
               example:
                 data:
-                - id: '788'
+                - id: '877'
                   type: user
                   attributes:
                     name: test user
-                    email: user_82@example.com
-                    nickname: test nickname
-                    role: admin
-                    created_at: '2026-05-08T00:15:51.970+09:00'
-                    sangaku_count: 0
-                    answer_count: 0
-                - id: '789'
-                  type: user
-                  attributes:
-                    name: test user
-                    email: user_83@example.com
+                    email: user_18@example.com
                     nickname: test nickname
                     role: general
-                    created_at: '2026-05-08T00:15:51.971+09:00'
+                    created_at: '2026-06-23T16:18:51.659+09:00'
+                    sangaku_count: 0
+                    answer_count: 0
+                - id: '876'
+                  type: user
+                  attributes:
+                    name: test user
+                    email: user_17@example.com
+                    nickname: test nickname
+                    role: admin
+                    created_at: '2026-06-23T16:18:51.657+09:00'
+                    sangaku_count: 0
+                    answer_count: 0
+                - id: '879'
+                  type: user
+                  attributes:
+                    name: test user
+                    email: user_20@example.com
+                    nickname: test nickname
+                    role: general
+                    created_at: '2026-06-22T16:18:51.662+09:00'
+                    sangaku_count: 0
+                    answer_count: 0
+                - id: '878'
+                  type: user
+                  attributes:
+                    name: test user
+                    email: user_19@example.com
+                    nickname: test nickname
+                    role: general
+                    created_at: '2026-06-21T16:18:51.660+09:00'
                     sangaku_count: 0
                     answer_count: 0
         '401':
@@ -133,6 +127,19 @@ paths:
               example:
                 message: Forbidden
                 errors: []
+      parameters:
+      - name: query
+        in: query
+        required: false
+        schema:
+          type: string
+        example: search_target@
+      - name: sort
+        in: query
+        required: false
+        schema:
+          type: string
+        example: desc
   "/api/v1/admin/users/{id}":
     get:
       summary: show
@@ -144,7 +151,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 801
+        example: 895
       responses:
         '200':
           description: returns 200 with user attributes
@@ -193,14 +200,14 @@ paths:
                 - data
               example:
                 data:
-                  id: '795'
+                  id: '889'
                   type: user
                   attributes:
                     name: test user
-                    email: user_89@example.com
+                    email: user_30@example.com
                     nickname: test nickname
                     role: general
-                    created_at: '2026-05-08T00:15:52.037+09:00'
+                    created_at: '2026-06-23T16:18:51.714+09:00'
                     sangaku_count: 0
                     answer_count: 0
         '401':
@@ -240,7 +247,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 822
+        example: 916
       requestBody:
         content:
           application/json:
@@ -313,14 +320,14 @@ paths:
                 - data
               example:
                 data:
-                  id: '810'
+                  id: '904'
                   type: user
                   attributes:
                     name: test user
-                    email: user_104@example.com
+                    email: user_45@example.com
                     nickname: test nickname
                     role: admin
-                    created_at: '2026-05-08T00:15:52.156+09:00'
+                    created_at: '2026-06-23T16:18:51.814+09:00'
                     sangaku_count: 0
                     answer_count: 0
         '401':

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -14,6 +14,90 @@ RSpec.describe "Api::V1::Admin::Users", type: :request do
         expect(response).to have_http_status(:ok)
         expect(body["data"]).to be_an(Array)
       end
+
+      context "with query parameter" do
+        let!(:matched_by_email) { create(:user, email: "search_target@example.com", nickname: "other") }
+        let!(:matched_by_nickname) { create(:user, email: "other@example.com", nickname: "search_target_nick") }
+        let!(:unmatched_user) { create(:user, email: "nomatch@example.com", nickname: "nomatch") }
+
+        it "returns only users matching query by email", openapi: false do
+          authenticate_stub(admin_user)
+          get api_v1_admin_users_path, params: { query: "search_target@" }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          ids = body["data"].map { |u| u["id"] }
+          expect(ids).to include(matched_by_email.id.to_s)
+          expect(ids).not_to include(unmatched_user.id.to_s)
+          expect(ids).not_to include(matched_by_nickname.id.to_s)
+        end
+
+        it "returns only users matching query by nickname", openapi: false do
+          authenticate_stub(admin_user)
+          get api_v1_admin_users_path, params: { query: "search_target_nick" }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          ids = body["data"].map { |u| u["id"] }
+          expect(ids).to include(matched_by_nickname.id.to_s)
+          expect(ids).not_to include(unmatched_user.id.to_s)
+        end
+
+        it "is case-insensitive", openapi: false do
+          authenticate_stub(admin_user)
+          get api_v1_admin_users_path, params: { query: "SEARCH_TARGET@" }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          ids = body["data"].map { |u| u["id"] }
+          expect(ids).to include(matched_by_email.id.to_s)
+        end
+
+        it "returns empty array when no users match", openapi: false do
+          authenticate_stub(admin_user)
+          get api_v1_admin_users_path, params: { query: "zzz_no_match_zzz" }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(body["data"]).to be_empty
+        end
+
+        it "returns all users when query is blank", openapi: false do
+          authenticate_stub(admin_user)
+          get api_v1_admin_users_path, params: { query: "" }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(body["data"].size).to eq(::User.count)
+        end
+      end
+
+      context "with sort parameter" do
+        let!(:older_user) { create(:user, created_at: 2.days.ago) }
+        let!(:newer_user) { create(:user, created_at: 1.day.ago) }
+
+        it "returns users in descending order by default", openapi: false do
+          authenticate_stub(admin_user)
+          get api_v1_admin_users_path, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          ids = body["data"].map { |u| u["id"].to_i }
+          expect(ids.index(older_user.id)).to be > ids.index(newer_user.id)
+        end
+
+        it "returns users in descending order when sort=desc", openapi: false do
+          authenticate_stub(admin_user)
+          get api_v1_admin_users_path, params: { sort: "desc" }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          ids = body["data"].map { |u| u["id"].to_i }
+          expect(ids.index(older_user.id)).to be > ids.index(newer_user.id)
+        end
+
+        it "returns users in ascending order when sort=asc", openapi: false do
+          authenticate_stub(admin_user)
+          get api_v1_admin_users_path, params: { sort: "asc" }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          ids = body["data"].map { |u| u["id"].to_i }
+          expect(ids.index(older_user.id)).to be < ids.index(newer_user.id)
+        end
+      end
     end
 
     context "as general user" do

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Api::V1::Admin::Users", type: :request do
         let!(:matched_by_nickname) { create(:user, email: "other@example.com", nickname: "search_target_nick") }
         let!(:unmatched_user) { create(:user, email: "nomatch@example.com", nickname: "nomatch") }
 
-        it "returns only users matching query by email", openapi: false do
+        it "returns only users matching query by email" do
           authenticate_stub(admin_user)
           get api_v1_admin_users_path, params: { query: "search_target@" }, headers: headers
 
@@ -80,7 +80,7 @@ RSpec.describe "Api::V1::Admin::Users", type: :request do
           expect(ids.index(older_user.id)).to be > ids.index(newer_user.id)
         end
 
-        it "returns users in descending order when sort=desc", openapi: false do
+        it "returns users in descending order when sort=desc" do
           authenticate_stub(admin_user)
           get api_v1_admin_users_path, params: { sort: "desc" }, headers: headers
 


### PR DESCRIPTION
## 概要

admin ユーザー一覧 API（`GET /api/v1/admin/users`）に `query` パラメータによる検索と `sort` パラメータによる登録日時ソートを追加します。

Closes #252

## 確認方法

1. `docker-compose up` でサービスを起動してください
2. `bundle exec rspec spec/requests/api/v1/admin/users_spec.rb` を実行し、23件全パスすることを確認してください
3. admin トークンで以下のリクエストが期待通り動作することを確認してください
   - `GET /api/v1/admin/users?query=example` → email/nickname に "example" を含むユーザーのみ返る
   - `GET /api/v1/admin/users?sort=asc` → 登録日時昇順で返る
   - `GET /api/v1/admin/users?sort=desc` → 登録日時降順で返る（デフォルト）

## 影響範囲

- `GET /api/v1/admin/users` のレスポンス内容（絞り込み・ソート順）
- 他の admin エンドポイント・一般ユーザー向けエンドポイントへの影響なし

## チェックリスト

- [x] インテグレーションテストを追加した
- [x] ユニットテストをパスした

## コメント

### セキュリティ対応

- `sanitize_sql_like` を `User.search` スコープ内で適用し、`%` `_` のワイルドカードエスケープを実施
- `params[:query].to_s` で Array/Hash 入力による `TypeError → 500` を防止
- `sort` パラメータは `%w[asc desc]` の許可リストで検証し、不正値はデフォルト（降順）にフォールバック

### 設計

- 検索ロジックを `User.search` スコープとして `app/models/user.rb` に切り出し、コントローラーに SQL 文字列を直書きしない設計に変更

### フロントエンド対応

- ソート UI（sort パラメータを送る機能）は別 issue（algo_sangaku_front#85）で対応予定