### PR TITLE
fix: コード品質・保守性の改善（issue #249 m-1〜m-11）

### DIFF
--- a/app/controllers/api/v1/admin/sangakus_controller.rb
+++ b/app/controllers/api/v1/admin/sangakus_controller.rb
@@ -5,7 +5,7 @@ module Api
         before_action :set_sangaku, only: %i[show update destroy]
 
         def index
-          @pagy, sangakus = pagy(::Sangaku.all.includes(:user, :shrine))
+          @pagy, sangakus = pagy(::Sangaku.all.includes(:user, :shrine).order(:id))
           render json: ::Admin::SangakuSerializer.new(sangakus).serializable_hash.to_json, status: :ok
         end
 

--- a/app/controllers/api/v1/admin/shrines_controller.rb
+++ b/app/controllers/api/v1/admin/shrines_controller.rb
@@ -5,7 +5,7 @@ module Api
         before_action :set_shrine, only: %i[show update destroy]
 
         def index
-          @pagy, shrines = pagy(::Shrine.all)
+          @pagy, shrines = pagy(::Shrine.all.order(:id))
           render json: ::Admin::ShrineSerializer.new(shrines).serializable_hash.to_json, status: :ok
         end
 

--- a/app/controllers/api/v1/user/sangakus_controller.rb
+++ b/app/controllers/api/v1/user/sangakus_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :set_sangaku, only: %i[show update destroy]
 
       def index
-        @pagy, sangakus = pagy(current_user.sangakus.search(search_params).includes(:fixed_inputs, :user, :shrine))
+        @pagy, sangakus = pagy(current_user.sangakus.search(search_params).order(:id).includes(:fixed_inputs, :user, :shrine))
         render json: SangakuSerializer.new(sangakus).serializable_hash.to_json, status: :ok
       end
 
@@ -47,12 +47,7 @@ module Api
           return render json: { error: "問題文は#{GENERATE_SOURCE_MAX_LENGTH}文字以内で入力してください" }, status: :unprocessable_entity
         end
 
-        if current_user.generate_source_daily_remaining <= 0
-          return render json: {
-            error: "本日の利用回数上限に達しました",
-            reset_at: current_user.generate_source_daily_reset_at.iso8601
-          }, status: :too_many_requests
-        end
+        check_generate_source_rate_limit!
 
         client = OpenAI::Client.new
         response = client.chat(
@@ -87,8 +82,12 @@ module Api
           return render json: { error: "コードの生成に失敗しました" }, status: :unprocessable_entity
         end
 
-        now = Time.current
-        current_user.generate_source_call_logs.create!(called_at: now)
+        now = nil
+        current_user.with_lock do
+          check_generate_source_rate_limit!
+          now = Time.current
+          current_user.generate_source_call_logs.create!(called_at: now)
+        end
 
         render json: {
           source: source,
@@ -100,7 +99,8 @@ module Api
           }
         }, status: :ok
       rescue OpenAI::Error => e
-        render json: { error: e.message }, status: :unprocessable_entity
+        Rails.logger.error("[generate_source] OpenAI error: #{e.message}")
+        render json: { error: "コードの生成中にエラーが発生しました" }, status: :unprocessable_entity
       end
 
       def generate_source_usage
@@ -114,6 +114,12 @@ module Api
       end
 
       private
+
+      def check_generate_source_rate_limit!
+        if current_user.generate_source_daily_remaining <= 0
+          raise TooManyRequestsError.new(reset_at: current_user.generate_source_daily_reset_at)
+        end
+      end
 
       def search_params
         params.permit(:title, :shrine_id, :difficulty)

--- a/app/controllers/concerns/api/exception_handler.rb
+++ b/app/controllers/concerns/api/exception_handler.rb
@@ -6,11 +6,13 @@ module Api::ExceptionHandler
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
     rescue_from ActionController::ParameterMissing, with: :render_400
     rescue_from ActiveRecord::RecordNotUnique, with: :render_409
+    rescue_from TooManyRequestsError, with: :render_429
   end
 
   private
 
   def render_400(exception = nil, messages = nil)
+    Rails.logger.warn("[render_400] #{exception&.message}") if exception
     render_error(400, "Bad Request", exception&.message, *messages)
   end
 
@@ -27,11 +29,16 @@ module Api::ExceptionHandler
     render_error(409, "Conflict")
   end
 
-  def render_error(code, message, *error_messages)
+  def render_429(exception = nil, messages = nil)
+    render_error(429, "Too Many Requests", exception&.message,
+                 reset_at: exception&.reset_at&.iso8601)
+  end
+
+  def render_error(code, message, *error_messages, **extra)
     res = {
       message: message,
       errors: error_messages.compact
-    }
+    }.merge(extra.compact)
 
     render json: res, status: code
   end

--- a/app/errors/too_many_requests_error.rb
+++ b/app/errors/too_many_requests_error.rb
@@ -1,0 +1,10 @@
+class TooManyRequestsError < StandardError
+  def initialize(reset_at:)
+    @reset_at = reset_at
+    super("本日の利用回数上限に達しました")
+  end
+
+  def reset_at
+    @reset_at
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -5,8 +5,11 @@ class ApiKey < ApplicationRecord
 
   scope :active, -> { where("expires_at >= ?", Time.current) }
 
-  def initialize(attributes = {})
-    super
+  after_initialize :set_defaults, if: :new_record?
+
+  private
+
+  def set_defaults
     self.access_token = SecureRandom.uuid
     self.expires_at = 1.week.after
   end

--- a/app/models/concerns/paizaio_api.rb
+++ b/app/models/concerns/paizaio_api.rb
@@ -4,7 +4,7 @@ module PaizaioApi
   MAX_POLL_ATTEMPTS = 30
 
   def run_source(source, input = "", language = "ruby")
-    id = create(source, language, input)
+    id = create_runner(source, language, input)
     status = "running"
     attempts = 0
 
@@ -19,7 +19,7 @@ module PaizaioApi
     get_details(id)
   end
 
-  def create(source, language, input)
+  def create_runner(source, language, input)
     api_url = "https://api.paiza.io/runners/create.json"
     uri = URI(api_url)
     http = Net::HTTP.new(uri.host, uri.port)

--- a/app/models/concerns/place_api.rb
+++ b/app/models/concerns/place_api.rb
@@ -105,45 +105,5 @@ module PlaceApi
         nil
       end
     end
-
-    def find_or_getdetals_by(ids)
-      api_uri = "https://places.googleapis.com/v1/places/"
-      api_key = ENV["GOOGLE_MAP_API_KEY"]
-
-      saved_shrines = self.where(place_id: ids)
-      saved_ids = saved_shrines.map { |shrine| shrine.place_id }
-
-      shrines = ids.map do |id|
-        next saved_shrines.select { |shrine| shrine.place_id == id }[0] if saved_ids.include?(id)
-
-        uri = URI.parse(api_uri + id)
-        params = {
-          fields: %w[id displayName formattedAddress location].join(","),
-          key: api_key,
-          languageCode: "JA"
-        }
-
-        uri.query = URI.encode_www_form(params)
-
-        res = Net::HTTP.get_response(uri)
-
-        if res.class == Net::HTTPOK
-          body = JSON.parse(res.body)
-
-          shrine = Shrine.new(name: body["displayName"]["text"],
-            address: body["formattedAddress"],
-            latitude: body["location"]["latitude"],
-            longitude: body["location"]["longitude"],
-            place_id: body["id"]
-          )
-
-          shrine.save!
-          shrine
-        else
-          nil
-        end
-      end
-      shrines
-    end
   end
 end

--- a/app/models/concerns/spherical_cosine_theorem.rb
+++ b/app/models/concerns/spherical_cosine_theorem.rb
@@ -10,8 +10,8 @@ module SphericalCosineTheorem
 
     6371 *
            Math.acos(
-             Math.cos(lat1) * Math.cos(lat2) * Math.cos(lng2 - lng1) +
-             Math.sin(lat1) * Math.sin(lat2)
+             (Math.cos(lat1) * Math.cos(lat2) * Math.cos(lng2 - lng1) +
+             Math.sin(lat1) * Math.sin(lat2)).clamp(-1.0, 1.0)
            )
   end
 end

--- a/app/models/sangaku.rb
+++ b/app/models/sangaku.rb
@@ -21,7 +21,7 @@ class Sangaku < ApplicationRecord
         { easy: 0, normal: 10, difficult: 20, very_difficult: 30 },
         prefix: true
 
-  scope :title_contain, ->(title) { where("title LIKE ?", "%#{title}%") }
+  scope :title_contain, ->(title) { where("title LIKE ?", "%#{sanitize_sql_like(title)}%") }
 
   def save_with_inputs(new_contents) # (str[] | nil) => boolean
     new_contents ||= []

--- a/app/models/shrine.rb
+++ b/app/models/shrine.rb
@@ -12,43 +12,22 @@ class Shrine < ApplicationRecord
 
   def self.search_by_bounds(low_lat, high_lat, low_lng, high_lng)
     search_result = self.text_search_by_location_restriction(low_lat, high_lat, low_lng, high_lng)
-    filtered_places = self.eleminate_non_shrine(search_result)
-
-    filtered_places.map! do |place|
-      {
-        name: place["displayName"]["text"],
-        address: place["formattedAddress"],
-        latitude: place["location"]["latitude"],
-        longitude: place["location"]["longitude"],
-        place_id: place["id"]
-      }
-    end
-
-    ActiveRecord::Base.transaction do
-      filtered_places.map! do |place|
-        shrine = Shrine.find_or_initialize_by(place_id: place[:place_id])
-
-        if shrine.persisted?
-          next shrine
-        else
-          shrine.assign_attributes(place)
-          shrine.save!
-          next shrine
-        end
-      end
-    end
-
-    filtered_places
-
+    persist_places(eleminate_non_shrine(search_result))
   rescue StandardError
     false
   end
 
   def self.search_by_location(lat, lng)
     search_result = self.text_search_by_location_bias(lat, lng)
-    filtered_places = self.eleminate_non_shrine(search_result)
+    persist_places(eleminate_non_shrine(search_result))
+  rescue StandardError
+    false
+  end
 
-    filtered_places.map! do |place|
+  private
+
+  def self.persist_places(filtered_places)
+    place_attrs = filtered_places.map do |place|
       {
         name: place["displayName"]["text"],
         address: place["formattedAddress"],
@@ -58,45 +37,24 @@ class Shrine < ApplicationRecord
       }
     end
 
-    ActiveRecord::Base.transaction do
-      filtered_places.map! do |place|
-        shrine = Shrine.find_or_initialize_by(place_id: place[:place_id])
+    existing = Shrine.where(place_id: place_attrs.map { |a| a[:place_id] }).index_by(&:place_id)
 
-        if shrine.persisted?
-          next shrine
-        else
-          shrine.assign_attributes(place)
-          shrine.save!
-          next shrine
-        end
+    ActiveRecord::Base.transaction do
+      place_attrs.map do |attrs|
+        shrine = existing[attrs[:place_id]] || Shrine.new(attrs)
+        shrine.save! unless shrine.persisted?
+        shrine
       end
     end
-
-    filtered_places
-
-  rescue StandardError
-    false
   end
 
-  private
-
   def self.eleminate_non_shrine(places)
-    eleminate_keyword = [ "寺", "手水舎", "社務所", "授与所", "鳥居" ]
-    filtered_places = []
-    places.map do |place|
-      flag = true
-
-      eleminate_keyword.map do |keyword|
-        break unless flag
-
-        flag = false if place["displayName"]["text"].include?(keyword)
-      end
-
-      if flag || place["displayName"]["text"].include?("社") && place["displayName"]["text"].include?("寺")
-        filtered_places << place
-      end
+    eliminate_keywords = [ "寺", "手水舎", "社務所", "授与所", "鳥居" ]
+    places.select do |place|
+      name = place["displayName"]["text"]
+      has_no_keyword = eliminate_keywords.none? { |kw| name.include?(kw) }
+      has_shrine_and_temple = name.include?("社") && name.include?("寺")
+      has_no_keyword || has_shrine_and_temple
     end
-
-    filtered_places
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_many :sangakus, dependent: :destroy
-  has_many :api_keys
+  has_many :api_keys, dependent: :destroy
   has_many :user_sangaku_saves, dependent: :destroy, class_name: "UserSangakuSave"
   has_many :saved_sangakus, through: :user_sangaku_saves, source: :sangaku
   has_many :answers, through: :user_sangaku_saves
@@ -40,11 +40,7 @@ class User < ApplicationRecord
   validates :email, length: { maximum: 255 }
   validates :nickname, presence: true, length: { maximum: 255 }
 
-  def initialize(attributes = {})
-    super
-    self.nickname = self.name if name.present? && !nickname.present?
-  end
-
+  after_initialize :set_defaults, if: :new_record?
 
   def add_saved_sangakus(sangaku)
     saved_sangakus << sangaku
@@ -52,5 +48,11 @@ class User < ApplicationRecord
 
   def dedicated_sangakus_with_shrine
     @dedicated_sangakus_with_shrine ||= sangakus.where.not(shrine_id: nil).includes(:shrine).to_a
+  end
+
+  private
+
+  def set_defaults
+    self.nickname = name if name.present? && nickname.blank?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   namespace :api, format: :json do
     namespace :v1 do
       resource :authenticate, only: %i[create destroy]
-      resources :sangakus, only: %i[index show] do
+      resources :sangakus, only: %i[show] do
         resource :save, only: %i[create], controller: "sangaku_saves"
       end
       resources :shrines, only: %i[index show] do

--- a/spec/requests/api/v1/user/sangakus_spec.rb
+++ b/spec/requests/api/v1/user/sangakus_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe "Api::V1::User::Sangakus", type: :request do
           http_request
         }.not_to change(GenerateSourceCallLog, :count)
         expect(response).to have_http_status(:too_many_requests)
-        expect(body["error"]).to be_present
+        expect(body["errors"].first).to be_present
         expect(body["reset_at"]).to be_present
       end
     end


### PR DESCRIPTION
## 概要

コードレビュー（2026-06-13）で発見された Minor 問題 12件のうち、m-1〜m-11 に対応する。
m-12（アクセストークンのダイジェスト保存）は既存トークンの移行計画が必要なため別途対応する。

Close #249

### 対応内容

| ID | 対象 | 対応内容 |
|----|------|---------|
| m-1 | `config/routes.rb` | `sangakus#index` をルートから除外（アクション未定義のため） |
| m-2 | `sangaku.rb` | `title_contain` scope に `sanitize_sql_like` を適用 |
| m-3 | `spherical_cosine_theorem.rb` | `Math.acos` 引数に `.clamp(-1.0, 1.0)` を追加 |
| m-4 | `api_key.rb` / `user.rb` | `initialize` オーバーライドを `after_initialize :set_defaults, if: :new_record?` に置換 |
| m-5 | `user.rb` | `has_many :api_keys` に `dependent: :destroy` を追加 |
| m-6 | `shrine.rb` | 重複コードを `persist_places` プライベートメソッドに抽出。バッチ取得に変更し N+1 も解消 |
| m-7 | `place_api.rb` | 未使用の `find_or_getdetals_by` を削除 |
| m-8 | `exception_handler.rb` / `sangakus_controller.rb` | 内部エラーメッセージをログに分離。ただし `ParameterMissing` 等 API 仕様上必要なメッセージは `errors[]` に継続して含める |
| m-9 | admin / user 各コントローラ | 一覧クエリに `.order(:id)` を追加 |
| m-10 | `sangakus_controller.rb` | AI 生成の日次制限を `with_lock` による check-then-act に変更。`TooManyRequestsError` を `rescue_from` で統一処理 |
| m-11 | `paizaio_api.rb` | `create` メソッドを `create_runner` にリネーム |

## 確認方法

1. テストを実行してください

```bash
docker-compose exec web bundle exec rspec spec/models/ spec/requests/
```

期待値: 189 examples, 0 failures

## 影響範囲

- `GET /api/v1/sangakus` が 404 になる（ルート削除。公開算額一覧は `GET /api/v1/shrines/:id/sangakus` から取得する設計）
- `POST /api/v1/user/sangakus/generate_source` の 429 レスポンス形式が変更
  - 旧: `{ error: "...", reset_at: "..." }`
  - 新: `{ message: "Too Many Requests", errors: ["..."], reset_at: "..." }`
- `render_error` に `**extra` キーワード引数を追加（後方互換あり）

## チェックリスト

- [x] ユニットテストをパスした（189 examples, 0 failures, カバレッジ 90.05%）
- [x] sider をパスした
- [x] Lint のチェックをパスした

## コメント

m-10 の競合対策について、`with_lock` を2段階（OpenAI 呼び出し前に plain read でファストフェール、呼び出し後に lock + 記録）としている。OpenAI 呼び出し中にロックを保持しないことで DB 負荷を抑えつつ、実際のカウント記録は原子的に行う設計。