### PR TITLE
fix: 算額保存APIのレスポンスから模範解答sourceを除外 (#261)

### DIFF
--- a/app/controllers/api/v1/sangaku_saves_controller.rb
+++ b/app/controllers/api/v1/sangaku_saves_controller.rb
@@ -5,7 +5,7 @@ module Api
         sangaku = Sangaku.find(params[:sangaku_id])
 
         current_user.add_saved_sangakus(sangaku)
-        render json: SangakuSerializer.new(sangaku).serializable_hash.to_json
+        render json: PublicSangakuSerializer.new(sangaku).serializable_hash.to_json
       end
     end
   end

--- a/spec/requests/api/v1/sangaku_saves_spec.rb
+++ b/spec/requests/api/v1/sangaku_saves_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe "Api::V1::Sangakus", type: :request do
         expect(response).to be_successful
         expect(response).to have_http_status(:ok)
       end
+
+      it "does not include the model answer source in the response" do
+        authenticate_stub(user)
+
+        http_request
+
+        json = JSON.parse(response.body)
+        expect(json["data"]["attributes"]).not_to have_key("source")
+        expect(response.body).not_to include(sangaku.source)
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

`POST /api/v1/sangakus/:sangaku_id/save`（算額保存API）のレスポンスに、出題者用の `SangakuSerializer`（模範解答コード `source` を含む）を使用していたため、解答者が他人の算額を保存した瞬間に模範解答がAPIレスポンスからそのまま読み取れてしまう問題を修正しました。

closes #261

## 確認方法

1. `sangaku_saves_controller.rb` が `PublicSangakuSerializer`（`source` を含まない）を使用するように変更したことを確認してください。
2. 任意のユーザーで他人の算額に対して save API を叩き、レスポンス JSON に `attributes.source` が含まれないことを確認してください。
3. `docker-compose exec web bundle exec rspec spec/requests/api/v1/sangaku_saves_spec.rb` でテストが通ることを確認してください。

## 影響範囲

- `app/controllers/api/v1/sangaku_saves_controller.rb` のみ変更。他のシリアライザ使用箇所への影響はありません。

## チェックリスト

- [x] `source` が含まれないことを検証するテストを追加した
- [x] 既存テストが通ることを確認した（rspec 全体: 196 examples, 0 failures）
- [x] Lint のチェックをパスした

## コメント

`REVIEW.md` の B-1 で指摘されていた最優先課題です。既に `Api::V1::User::SavedSangakus` の別テストで同種の「source非漏洩」検証パターンが存在しており、今回の修正はそれと一貫性があります。