### PR TITLE
fix: PaizaIOレスポンスのキー誤りを修正（stderror→stderr）

### DIFF
--- a/app/models/answer_result.rb
+++ b/app/models/answer_result.rb
@@ -22,12 +22,12 @@ class AnswerResult < ApplicationRecord
     new_status = "pending"
     output = ""
 
-    if answer_result["stderror"].blank?
+    if answer_result["stderr"].blank?
       new_status = answer_result["stdout"] == correct_stdout ? "correct" : "incorrect"
       output = answer_result["stdout"]
     else
       new_status = "incorrect"
-      output = answer_result["stderror"]
+      output = answer_result["stderr"]
     end
 
     update!(status: new_status, output:)

--- a/spec/jobs/correctness_check_job_spec.rb
+++ b/spec/jobs/correctness_check_job_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe CorrectnessCheckJob, type: :job do
       expect(answer_result.reload.status).to eq("correct")
     end
 
+    it 'updates output to the stderr message and status to incorrect when the code raises a runtime error' do
+      stub_paizaio_api(stderr: "NoMethodError: undefined method\n")
+
+      CorrectnessCheckJob.perform_now(answer_result)
+      expect(answer_result.reload.output).to eq("NoMethodError: undefined method\n")
+      expect(answer_result.reload.status).to eq("incorrect")
+    end
+
     it 'sets status to error after exhausting retries' do
       allow_any_instance_of(AnswerResult).to receive(:update_status).and_raise(StandardError, "PaizaIO error")
 

--- a/spec/support/paizaio_stubs.rb
+++ b/spec/support/paizaio_stubs.rb
@@ -1,5 +1,5 @@
 module PaizaioStubs
-  def stub_paizaio_api(stdout: "Hello world\n")
+  def stub_paizaio_api(stdout: "Hello world\n", stderr: "")
     stub_request(:post, "https://api.paiza.io/runners/create.json")
       .to_return(
         status: 200,
@@ -17,7 +17,16 @@ module PaizaioStubs
     stub_request(:get, /api\.paiza\.io.*get_details/)
       .to_return(
         status: 200,
-        body: { stdout: stdout, stderror: "" }.to_json,
+        body: {
+          build_stdout: "",
+          build_stderr: "",
+          build_exit_code: 0,
+          build_result: "success",
+          stdout: stdout,
+          stderr: stderr,
+          exit_code: 0,
+          result: "success"
+        }.to_json,
         headers: { "Content-Type" => "application/json" }
       )
   end


### PR DESCRIPTION
## 概要

`AnswerResult#update_status` が PaizaIO の `get_details` レスポンスに存在しない `stderror` キーを参照していたため、実行時エラーが発生しても常に `nil`（blank）扱いとなり、正常系（stdout比較）の分岐に入ってしまいエラーメッセージが一切ユーザーに表示されない不具合を修正しました。

正しいキー名は Swagger 定義（https://api.paiza.io/docs/swagger/#!/runners/ / `https://api.paiza.io/runners.json`）で確認済みです。front側の同等実装 `runSource`（`front/app/lib/actions/sangaku.ts`）ではすでに正しく `stderr` / `build_stderr` を参照しており、back側のみ誤記でした。

Closes #262

## 修正内容

- `app/models/answer_result.rb`: `answer_result["stderror"]` → `answer_result["stderr"]` に修正（25行目・30行目）
- `spec/support/paizaio_stubs.rb`: テストスタブの `get_details` レスポンスを実APIレスポンス形状（`build_stdout`/`build_stderr`/`build_exit_code`/`build_result`/`stdout`/`stderr`/`exit_code`/`result`）に合わせて修正。`stderr` を引数で指定できるように変更
- `spec/jobs/correctness_check_job_spec.rb`: 実行時エラー（stderrあり）の場合に `output` にエラーメッセージが入り `status` が `incorrect` になることを確認するテストを追加

## スコープ外（別issue検討）

- `build_stderr`（構文/ビルドエラー）のハンドリング追加
- back/front で PaizaIO 実行ロジックが重複実装されている問題（`REVIEW.md` M-1）

## 確認方法

1. `bundle exec rspec spec/jobs/correctness_check_job_spec.rb spec/models/answer_result_spec.rb` を実行し、追加したテストを含めて全てパスすることを確認
2. 提出コードが実行時エラー（例: `NoMethodError` など）になるケースで、`AnswerResult#output` に実際のエラーメッセージが保存されることを確認

## 影響範囲

- `AnswerResult#update_status` のみ。API/シリアライザ層への影響なし
- テストスタブ（`stub_paizaio_api`）を利用する全テストのレスポンス形状が変わるが、キー追加のみで既存テストの期待値には影響なし（実行済み: 全体スイート 197 examples, 0 failures）

## チェックリスト

- [x] インテグレーションテストを追加した
- [x] Lint（RuboCop）のチェックをパスした
- [x] ユニットテストをパスした
- [ ] 必要なドキュメントを作成した（該当なし）

## コメント

- `stderr` 検知時の `status` は現状維持（`incorrect`）としています。enum に定義済みの `error(30)` は今回使用していません
- `build_stderr` 対応は別issueとして切り出すことを検討ください