### PR TITLE
[Major] 算額作成/更新リクエスト内でのPaizaIO同期実行を非同期化

### DIFF
--- a/app/jobs/generate_expected_output_job.rb
+++ b/app/jobs/generate_expected_output_job.rb
@@ -1,0 +1,12 @@
+class GenerateExpectedOutputJob < ApplicationJob
+  include PaizaioApi
+
+  queue_as :default
+
+  def perform(fixed_input)
+    result = run_source(fixed_input.sangaku.source, fixed_input.content)
+    fixed_input.update_columns(expected_output: result["stdout"])
+  rescue StandardError
+    # PaizaIO 失敗時は nil のまま。採点時に都度実行するフォールバックに任せる
+  end
+end

--- a/app/models/fixed_input.rb
+++ b/app/models/fixed_input.rb
@@ -1,6 +1,4 @@
 class FixedInput < ApplicationRecord
-  include PaizaioApi
-
   belongs_to :sangaku
 
   has_many :answer_results
@@ -13,9 +11,6 @@ class FixedInput < ApplicationRecord
   private
 
   def generate_expected_output
-    result = run_source(sangaku.source, content)
-    update_columns(expected_output: result["stdout"])
-  rescue StandardError
-    # PaizaIO 失敗時は nil のまま。採点時に都度実行するフォールバックに任せる
+    GenerateExpectedOutputJob.perform_later(self)
   end
 end

--- a/spec/jobs/generate_expected_output_job_spec.rb
+++ b/spec/jobs/generate_expected_output_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe GenerateExpectedOutputJob, type: :job do
+  let!(:fixed_input) { create(:fixed_input, expected_output: nil) }
+
+  describe '#perform' do
+    it 'enqueues the job' do
+      ActiveJob::Base.queue_adapter = :test
+      GenerateExpectedOutputJob.perform_later(fixed_input)
+      expect(GenerateExpectedOutputJob).to have_been_enqueued
+    end
+
+    it 'updates expected_output when PaizaIO succeeds' do
+      GenerateExpectedOutputJob.perform_now(fixed_input)
+      expect(fixed_input.reload.expected_output).to eq("Hello world\n")
+    end
+
+    it 'leaves expected_output as nil when PaizaIO fails' do
+      allow_any_instance_of(GenerateExpectedOutputJob).to receive(:run_source).and_raise(StandardError, "PaizaIO error")
+
+      GenerateExpectedOutputJob.perform_now(fixed_input)
+      expect(fixed_input.reload.expected_output).to be_nil
+    end
+  end
+end

--- a/spec/models/fixed_input_spec.rb
+++ b/spec/models/fixed_input_spec.rb
@@ -22,4 +22,17 @@ RSpec.describe FixedInput, type: :model do
       expect(another_input.errors[:content]).to eq [ 'はすでに存在します' ]
     end
   end
+
+  describe 'callbacks' do
+    it 'enqueues GenerateExpectedOutputJob after create' do
+      ActiveJob::Base.queue_adapter = :test
+      expect { create(:fixed_input) }.to have_enqueued_job(GenerateExpectedOutputJob)
+    end
+
+    it 'enqueues GenerateExpectedOutputJob after update' do
+      input = create(:fixed_input)
+      ActiveJob::Base.queue_adapter = :test
+      expect { input.update(content: 'updated_content') }.to have_enqueued_job(GenerateExpectedOutputJob)
+    end
+  end
 end


### PR DESCRIPTION
## 概要

`FixedInput` の `after_commit` フックが作成/更新のたびに PaizaIO への同期HTTP呼び出し（最大3秒程度のポーリング込み）を Web リクエストのスレッド内で実行しており、テストケースをN件持つ算額の作成/更新リクエストが「N × (HTTP往復 + 最大約3秒)」ブロックしていた（Pumaワーカーの占有、フロントのタイムアウト、UX劣化）。

期待出力の生成処理を `GenerateExpectedOutputJob`（Solid Queue）に切り出し、`after_commit` では enqueue のみを行うように変更した。

Closes #263

## 確認方法

1. `bundle exec rspec spec/models/fixed_input_spec.rb spec/jobs/generate_expected_output_job_spec.rb spec/jobs/correctness_check_job_spec.rb spec/models/answer_result_spec.rb` が全てパスすることを確認
2. 算額作成/更新APIが PaizaIO の応答を待たずに即座にレスポンスを返すことを確認
3. PaizaIO 実行が失敗した場合（`expected_output` が `nil` のまま）でも、`AnswerResult#cached_expected_output` の既存フォールバック（採点時に `sangaku.source` を都度実行）により採点フローが従来通り動作することを確認

## 影響範囲

- `FixedInput` 作成/更新時の挙動が同期実行→非同期実行（ジョブ enqueue）に変わる
- `CorrectnessCheckJob` / `AnswerResult` のロジックは変更なし（既存のフォールバックに依存）
- DBスキーマ変更なし

## チェックリスト

- [x] ユニットテストを追加した
- [x] RuboCop のチェックをパスした
- [x] 既存テストが全てパス（202 examples, 0 failures）

## コメント

- リトライ方針は既存の `generate_expected_output` を踏襲し、失敗時はリトライせずそのまま `nil` フォールバックに任せる形にした（`CorrectnessCheckJob` のような `retry_on` は追加していない）
- `FixedInput` からは `PaizaioApi` concern の include を削除し、ロジックは `GenerateExpectedOutputJob` に完全移動した

🤖 Generated with [Claude Code](https://claude.com/claude-code)