### PR TITLE
fix: rescue StandardErrorによる広範なエラー握りつぶしを修正 (#265)

### DIFF
--- a/app/models/sangaku.rb
+++ b/app/models/sangaku.rb
@@ -42,7 +42,7 @@ class Sangaku < ApplicationRecord
     end
 
     true
-  rescue StandardError => e
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
     false
   end
 
@@ -78,7 +78,7 @@ class Sangaku < ApplicationRecord
     self.shrine = new_shrine
     save!
     true
-  rescue StandardError
+  rescue ActiveRecord::RecordInvalid
     false
   end
 

--- a/app/models/shrine.rb
+++ b/app/models/shrine.rb
@@ -12,15 +12,19 @@ class Shrine < ApplicationRecord
 
   def self.search_by_bounds(low_lat, high_lat, low_lng, high_lng)
     search_result = self.text_search_by_location_restriction(low_lat, high_lat, low_lng, high_lng)
+    return false if search_result.nil?
+
     persist_places(eleminate_non_shrine(search_result))
-  rescue StandardError
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
     false
   end
 
   def self.search_by_location(lat, lng)
     search_result = self.text_search_by_location_bias(lat, lng)
+    return false if search_result.nil?
+
     persist_places(eleminate_non_shrine(search_result))
-  rescue StandardError
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
     false
   end
 

--- a/spec/models/sangaku_spec.rb
+++ b/spec/models/sangaku_spec.rb
@@ -26,4 +26,45 @@ RSpec.describe Sangaku, type: :model do
       expect(sangaku.errors[:source]).to eq [ 'を入力してください' ]
     end
   end
+
+  describe '#save_with_inputs' do
+    it 'returns false when save! raises ActiveRecord::RecordInvalid' do
+      sangaku = create(:sangaku)
+      allow(sangaku).to receive(:save!).and_raise(ActiveRecord::RecordInvalid.new(sangaku))
+
+      expect(sangaku.save_with_inputs([])).to eq false
+    end
+
+    it 'returns false when save! raises ActiveRecord::RecordNotUnique' do
+      sangaku = create(:sangaku)
+      allow(sangaku).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique.new("duplicate key"))
+
+      expect(sangaku.save_with_inputs([])).to eq false
+    end
+
+    it 'raises when an unexpected error occurs' do
+      sangaku = create(:sangaku)
+      allow(sangaku).to receive(:save!).and_raise(StandardError, "unexpected error")
+
+      expect { sangaku.save_with_inputs([]) }.to raise_error(StandardError, "unexpected error")
+    end
+  end
+
+  describe '#dedicate' do
+    it 'returns false when save! raises ActiveRecord::RecordInvalid' do
+      sangaku = create(:sangaku)
+      shrine = create(:shrine)
+      allow(sangaku).to receive(:save!).and_raise(ActiveRecord::RecordInvalid.new(sangaku))
+
+      expect(sangaku.dedicate(shrine, shrine.latitude, shrine.longitude)).to eq false
+    end
+
+    it 'raises when an unexpected error occurs' do
+      sangaku = create(:sangaku)
+      shrine = create(:shrine)
+      allow(sangaku).to receive(:save!).and_raise(StandardError, "unexpected error")
+
+      expect { sangaku.dedicate(shrine, shrine.latitude, shrine.longitude) }.to raise_error(StandardError, "unexpected error")
+    end
+  end
 end

--- a/spec/models/shrine_spec.rb
+++ b/spec/models/shrine_spec.rb
@@ -66,4 +66,48 @@ RSpec.describe Shrine, type: :model do
       expect(another_shirne.errors).to be_empty
     end
   end
+
+  describe '.search_by_bounds' do
+    it 'returns false when persist_places raises ActiveRecord::RecordInvalid' do
+      allow(Shrine).to receive(:text_search_by_location_restriction).and_return([])
+      allow(Shrine).to receive(:persist_places).and_raise(ActiveRecord::RecordInvalid.new(Shrine.new))
+
+      expect(Shrine.search_by_bounds(1, 2, 3, 4)).to eq false
+    end
+
+    it 'returns false when persist_places raises ActiveRecord::RecordNotUnique' do
+      allow(Shrine).to receive(:text_search_by_location_restriction).and_return([])
+      allow(Shrine).to receive(:persist_places).and_raise(ActiveRecord::RecordNotUnique.new("duplicate key"))
+
+      expect(Shrine.search_by_bounds(1, 2, 3, 4)).to eq false
+    end
+
+    it 'raises when an unexpected error occurs' do
+      allow(Shrine).to receive(:text_search_by_location_restriction).and_raise(StandardError, "api down")
+
+      expect { Shrine.search_by_bounds(1, 2, 3, 4) }.to raise_error(StandardError, "api down")
+    end
+  end
+
+  describe '.search_by_location' do
+    it 'returns false when persist_places raises ActiveRecord::RecordInvalid' do
+      allow(Shrine).to receive(:text_search_by_location_bias).and_return([])
+      allow(Shrine).to receive(:persist_places).and_raise(ActiveRecord::RecordInvalid.new(Shrine.new))
+
+      expect(Shrine.search_by_location(1, 2)).to eq false
+    end
+
+    it 'returns false when persist_places raises ActiveRecord::RecordNotUnique' do
+      allow(Shrine).to receive(:text_search_by_location_bias).and_return([])
+      allow(Shrine).to receive(:persist_places).and_raise(ActiveRecord::RecordNotUnique.new("duplicate key"))
+
+      expect(Shrine.search_by_location(1, 2)).to eq false
+    end
+
+    it 'raises when an unexpected error occurs' do
+      allow(Shrine).to receive(:text_search_by_location_bias).and_raise(StandardError, "api down")
+
+      expect { Shrine.search_by_location(1, 2) }.to raise_error(StandardError, "api down")
+    end
+  end
 end

--- a/spec/models/shrine_spec.rb
+++ b/spec/models/shrine_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe Shrine, type: :model do
   end
 
   describe '.search_by_bounds' do
+    it 'returns false when text search returns nil' do
+      allow(Shrine).to receive(:text_search_by_location_restriction).and_return(nil)
+
+      expect(Shrine.search_by_bounds(1, 2, 3, 4)).to eq false
+    end
+
     it 'returns false when persist_places raises ActiveRecord::RecordInvalid' do
       allow(Shrine).to receive(:text_search_by_location_restriction).and_return([])
       allow(Shrine).to receive(:persist_places).and_raise(ActiveRecord::RecordInvalid.new(Shrine.new))
@@ -90,6 +96,12 @@ RSpec.describe Shrine, type: :model do
   end
 
   describe '.search_by_location' do
+    it 'returns false when text search returns nil' do
+      allow(Shrine).to receive(:text_search_by_location_bias).and_return(nil)
+
+      expect(Shrine.search_by_location(1, 2)).to eq false
+    end
+
     it 'returns false when persist_places raises ActiveRecord::RecordInvalid' do
       allow(Shrine).to receive(:text_search_by_location_bias).and_return([])
       allow(Shrine).to receive(:persist_places).and_raise(ActiveRecord::RecordInvalid.new(Shrine.new))


### PR DESCRIPTION
## 概要
#265 の対応。`sangaku.rb`（`save_with_inputs`, `dedicate`）と `shrine.rb`（`search_by_bounds`, `search_by_location`）で `rescue StandardError` により、バリデーションエラーとDB障害・外部API障害・コーディングバグ等の予期しない例外が全て同じ `false`（→400）に握りつぶされていた問題を修正。

rescue対象を `ActiveRecord::RecordInvalid` / `ActiveRecord::RecordNotUnique`（バリデーションエラー相当）に絞り込み、それ以外の予期しない例外は既存の `exception_handler`（`rescue_from StandardError, with: :render_500`）まで伝播させ500として扱うようにした。

併せて、`shrine.rb` の検索メソッドが `PlaceApi` からの `nil`（引数不足）を暗黙的に例外経由でfalse化していた箇所に、明示的なnilガードを追加した（rescue絞り込みにより顕在化した回帰の修正）。

## 確認方法
1. `docker-compose exec web bundle exec rspec spec/models/sangaku_spec.rb spec/models/shrine_spec.rb` で新規テストが通ることを確認
2. `docker-compose exec web bundle exec rspec` で全体テストにリグレッションがないことを確認
3. `app/models/sangaku.rb` / `app/models/shrine.rb` の該当4メソッドのrescue節を確認

## 影響範囲
- `app/models/sangaku.rb`、`app/models/shrine.rb` のみ（コントローラ・ルーティング・シリアライザは変更なし）
- バリデーションエラー時の挙動（400 + errors.messages）は変更なし
- 予期しない障害時のみ挙動が変わる（従来: 400 → 変更後: 500 として`exception_handler`に伝播）

## チェックリスト
- [x] ユニットテストを追加した
- [x] 既存テストがパスすることを確認した（215+17 examples, 0 failures）
- [x] Lint のチェックをパスした

## コメント
- ログ出力は今回のスコープに含めていません（issue本文をあわせて更新済み）。バリデーションエラーは `errors.messages` として呼び出し元に伝わるため、モデル層でのログは冗長と判断しました。
- Google Places APIが非200応答を返した場合も内部的には `nil`（引数不足と同じ扱い）となり400になる問題が残っています。これは `PlaceApi` の設計に起因するため、フォローアップissue #271 で別途対応予定です。

関連: #265, #271