### PR TITLE
fix: PlaceApiでGoogle API障害と引数不足を区別する

### DIFF
--- a/app/errors/place_api_request_failed_error.rb
+++ b/app/errors/place_api_request_failed_error.rb
@@ -1,0 +1,1 @@
+class PlaceApiRequestFailedError < StandardError; end

--- a/app/errors/place_api_request_failed_error.rb
+++ b/app/errors/place_api_request_failed_error.rb
@@ -1,1 +1,8 @@
-class PlaceApiRequestFailedError < StandardError; end
+class PlaceApiRequestFailedError < StandardError
+  attr_reader :status_code
+
+  def initialize(status_code, message = "Google Places API request failed")
+    @status_code = status_code
+    super("#{message} (status: #{status_code})")
+  end
+end

--- a/app/models/concerns/place_api.rb
+++ b/app/models/concerns/place_api.rb
@@ -76,7 +76,7 @@ module PlaceApi
         data = JSON.parse(response.body)
         data["places"]
       else
-        raise PlaceApiRequestFailedError, "Google Places API request failed"
+        raise PlaceApiRequestFailedError, response.code
       end
     end
   end

--- a/app/models/concerns/place_api.rb
+++ b/app/models/concerns/place_api.rb
@@ -1,16 +1,11 @@
 module PlaceApi
   extend ActiveSupport::Concern
 
+  GOOGLE_PLACES_SEARCH_TEXT_URI = "https://places.googleapis.com/v1/places:searchText"
+
   class_methods do
     def text_search_by_location_restriction(low_lat, high_lat, low_lng, high_lng)
       return nil unless low_lat && high_lat && low_lng && high_lng
-
-      api_key = ENV["GOOGLE_MAP_API_KEY"]
-      api_uri = "https://places.googleapis.com/v1/places:searchText"
-
-      uri = URI.parse(api_uri)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme === "https"
 
       params = {
         "textQuery" => "神社 -寺",
@@ -32,39 +27,11 @@ module PlaceApi
         "rankPreference" => "DISTANCE"
       }
 
-      headers = {
-        "Content-Type" => "application/json",
-        "X-Goog-Api-Key" => api_key,
-        "X-Goog-Fieldmask" => "places.displayName,places.id,places.formattedAddress,places.location"
-      }
-
-      req = Net::HTTP::Post.new(uri.path)
-      req.body = params.to_json
-      req.initialize_http_header(headers)
-      response = http.request(req)
-
-      case response
-      when Net::HTTPOK
-        data= JSON.parse(response.body)
-        # p data
-        data["places"]
-      else
-        # p response.code
-        # p JSON.parse(response.body)
-        nil
-      end
+      perform_search_text_request(params)
     end
-
 
     def text_search_by_location_bias(lat, lng)
       return nil unless lat && lng
-
-      api_key = ENV["GOOGLE_MAP_API_KEY"]
-      api_uri = "https://places.googleapis.com/v1/places:searchText"
-
-      uri = URI.parse(api_uri)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme === "https"
 
       params = {
         "textQuery" => "神社 -寺",
@@ -83,9 +50,19 @@ module PlaceApi
         "rankPreference" => "DISTANCE"
       }
 
+      perform_search_text_request(params)
+    end
+
+    private
+
+    def perform_search_text_request(params)
+      uri = URI.parse(GOOGLE_PLACES_SEARCH_TEXT_URI)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme === "https"
+
       headers = {
         "Content-Type" => "application/json",
-        "X-Goog-Api-Key" => api_key,
+        "X-Goog-Api-Key" => ENV["GOOGLE_MAP_API_KEY"],
         "X-Goog-Fieldmask" => "places.displayName,places.id,places.formattedAddress,places.location"
       }
 
@@ -96,13 +73,10 @@ module PlaceApi
 
       case response
       when Net::HTTPOK
-        data= JSON.parse(response.body)
-        # p data
+        data = JSON.parse(response.body)
         data["places"]
       else
-        # p response.code
-        # p JSON.parse(response.body)
-        nil
+        raise PlaceApiRequestFailedError, "Google Places API request failed"
       end
     end
   end

--- a/spec/models/concerns/place_api_spec.rb
+++ b/spec/models/concerns/place_api_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe PlaceApi, type: :model do
     end
 
     context "when Google Places API returns a non-200 response" do
-      it "raises PlaceApiRequestFailedError when the API responds with 500" do
+      it "raises PlaceApiRequestFailedError with status_code 500 when the API responds with 500" do
         # Arrange
         stub_request(:post, search_text_uri)
           .to_return(status: 500, body: { error: "Internal Server Error" }.to_json, headers: {})
@@ -100,10 +100,10 @@ RSpec.describe PlaceApi, type: :model do
         # Act & Assert
         expect {
           Shrine.text_search_by_location_restriction(35.4, 35.5, 135.1, 135.2)
-        }.to raise_error(PlaceApiRequestFailedError)
+        }.to raise_error(PlaceApiRequestFailedError) { |error| expect(error.status_code).to eq("500") }
       end
 
-      it "raises PlaceApiRequestFailedError when the API responds with 429" do
+      it "raises PlaceApiRequestFailedError with status_code 429 when the API responds with 429" do
         # Arrange
         stub_request(:post, search_text_uri)
           .to_return(status: 429, body: { error: "Too Many Requests" }.to_json, headers: {})
@@ -111,7 +111,7 @@ RSpec.describe PlaceApi, type: :model do
         # Act & Assert
         expect {
           Shrine.text_search_by_location_restriction(35.4, 35.5, 135.1, 135.2)
-        }.to raise_error(PlaceApiRequestFailedError)
+        }.to raise_error(PlaceApiRequestFailedError) { |error| expect(error.status_code).to eq("429") }
       end
     end
   end
@@ -171,7 +171,7 @@ RSpec.describe PlaceApi, type: :model do
     end
 
     context "when Google Places API returns a non-200 response" do
-      it "raises PlaceApiRequestFailedError when the API responds with 500" do
+      it "raises PlaceApiRequestFailedError with status_code 500 when the API responds with 500" do
         # Arrange
         stub_request(:post, search_text_uri)
           .to_return(status: 500, body: { error: "Internal Server Error" }.to_json, headers: {})
@@ -179,10 +179,10 @@ RSpec.describe PlaceApi, type: :model do
         # Act & Assert
         expect {
           Shrine.text_search_by_location_bias(35.4, 135.1)
-        }.to raise_error(PlaceApiRequestFailedError)
+        }.to raise_error(PlaceApiRequestFailedError) { |error| expect(error.status_code).to eq("500") }
       end
 
-      it "raises PlaceApiRequestFailedError when the API responds with 429" do
+      it "raises PlaceApiRequestFailedError with status_code 429 when the API responds with 429" do
         # Arrange
         stub_request(:post, search_text_uri)
           .to_return(status: 429, body: { error: "Too Many Requests" }.to_json, headers: {})
@@ -190,7 +190,7 @@ RSpec.describe PlaceApi, type: :model do
         # Act & Assert
         expect {
           Shrine.text_search_by_location_bias(35.4, 135.1)
-        }.to raise_error(PlaceApiRequestFailedError)
+        }.to raise_error(PlaceApiRequestFailedError) { |error| expect(error.status_code).to eq("429") }
       end
     end
   end

--- a/spec/models/concerns/place_api_spec.rb
+++ b/spec/models/concerns/place_api_spec.rb
@@ -1,0 +1,197 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe PlaceApi, type: :model do
+  let(:search_text_uri) { "https://places.googleapis.com/v1/places:searchText" }
+  let(:dummy_places) do
+    [
+      {
+        "id" => "dummy_place_id",
+        "formattedAddress" => "dummy address",
+        "location" => { "latitude" => 35.4, "longitude" => 135.1 },
+        "displayName" => { "text" => "dummy神社", "language" => "ja" }
+      }
+    ]
+  end
+  let(:dummy_body) { { "places" => dummy_places }.to_json }
+
+  describe ".text_search_by_location_restriction" do
+    context "when required arguments are missing" do
+      it "returns nil when low_lat is nil" do
+        # Arrange
+        # low_lat が nil のケース
+
+        # Act
+        result = Shrine.text_search_by_location_restriction(nil, 2, 3, 4)
+
+        # Assert
+        expect(result).to be_nil
+      end
+
+      it "returns nil when high_lat is nil" do
+        # Arrange
+        # high_lat が nil のケース
+
+        # Act
+        result = Shrine.text_search_by_location_restriction(1, nil, 3, 4)
+
+        # Assert
+        expect(result).to be_nil
+      end
+
+      it "returns nil when low_lng is nil" do
+        # Arrange
+        # low_lng が nil のケース
+
+        # Act
+        result = Shrine.text_search_by_location_restriction(1, 2, nil, 4)
+
+        # Assert
+        expect(result).to be_nil
+      end
+
+      it "returns nil when high_lng is nil" do
+        # Arrange
+        # high_lng が nil のケース
+
+        # Act
+        result = Shrine.text_search_by_location_restriction(1, 2, 3, nil)
+
+        # Assert
+        expect(result).to be_nil
+      end
+
+      it "does not send an HTTP request when arguments are missing" do
+        # Arrange
+        # 引数不足時に外部APIへリクエストが飛ばないことを確認する
+
+        # Act
+        Shrine.text_search_by_location_restriction(nil, 2, 3, 4)
+
+        # Assert
+        expect(WebMock).not_to have_requested(:post, search_text_uri)
+      end
+    end
+
+    context "when Google Places API returns 200 OK" do
+      before do
+        stub_request(:post, search_text_uri)
+          .to_return(status: 200, body: dummy_body, headers: {})
+      end
+
+      it "returns the places array from the response body" do
+        # Arrange
+        # 200 OK 応答が dummy_body を返すようスタブ済み
+
+        # Act
+        result = Shrine.text_search_by_location_restriction(35.4, 35.5, 135.1, 135.2)
+
+        # Assert
+        expect(result).to eq(dummy_places)
+      end
+    end
+
+    context "when Google Places API returns a non-200 response" do
+      it "raises PlaceApiRequestFailedError when the API responds with 500" do
+        # Arrange
+        stub_request(:post, search_text_uri)
+          .to_return(status: 500, body: { error: "Internal Server Error" }.to_json, headers: {})
+
+        # Act & Assert
+        expect {
+          Shrine.text_search_by_location_restriction(35.4, 35.5, 135.1, 135.2)
+        }.to raise_error(PlaceApiRequestFailedError)
+      end
+
+      it "raises PlaceApiRequestFailedError when the API responds with 429" do
+        # Arrange
+        stub_request(:post, search_text_uri)
+          .to_return(status: 429, body: { error: "Too Many Requests" }.to_json, headers: {})
+
+        # Act & Assert
+        expect {
+          Shrine.text_search_by_location_restriction(35.4, 35.5, 135.1, 135.2)
+        }.to raise_error(PlaceApiRequestFailedError)
+      end
+    end
+  end
+
+  describe ".text_search_by_location_bias" do
+    context "when required arguments are missing" do
+      it "returns nil when lat is nil" do
+        # Arrange
+        # lat が nil のケース
+
+        # Act
+        result = Shrine.text_search_by_location_bias(nil, 135.1)
+
+        # Assert
+        expect(result).to be_nil
+      end
+
+      it "returns nil when lng is nil" do
+        # Arrange
+        # lng が nil のケース
+
+        # Act
+        result = Shrine.text_search_by_location_bias(35.4, nil)
+
+        # Assert
+        expect(result).to be_nil
+      end
+
+      it "does not send an HTTP request when arguments are missing" do
+        # Arrange
+        # 引数不足時に外部APIへリクエストが飛ばないことを確認する
+
+        # Act
+        Shrine.text_search_by_location_bias(nil, 135.1)
+
+        # Assert
+        expect(WebMock).not_to have_requested(:post, search_text_uri)
+      end
+    end
+
+    context "when Google Places API returns 200 OK" do
+      before do
+        stub_request(:post, search_text_uri)
+          .to_return(status: 200, body: dummy_body, headers: {})
+      end
+
+      it "returns the places array from the response body" do
+        # Arrange
+        # 200 OK 応答が dummy_body を返すようスタブ済み
+
+        # Act
+        result = Shrine.text_search_by_location_bias(35.4, 135.1)
+
+        # Assert
+        expect(result).to eq(dummy_places)
+      end
+    end
+
+    context "when Google Places API returns a non-200 response" do
+      it "raises PlaceApiRequestFailedError when the API responds with 500" do
+        # Arrange
+        stub_request(:post, search_text_uri)
+          .to_return(status: 500, body: { error: "Internal Server Error" }.to_json, headers: {})
+
+        # Act & Assert
+        expect {
+          Shrine.text_search_by_location_bias(35.4, 135.1)
+        }.to raise_error(PlaceApiRequestFailedError)
+      end
+
+      it "raises PlaceApiRequestFailedError when the API responds with 429" do
+        # Arrange
+        stub_request(:post, search_text_uri)
+          .to_return(status: 429, body: { error: "Too Many Requests" }.to_json, headers: {})
+
+        # Act & Assert
+        expect {
+          Shrine.text_search_by_location_bias(35.4, 135.1)
+        }.to raise_error(PlaceApiRequestFailedError)
+      end
+    end
+  end
+end

--- a/spec/models/shrine_spec.rb
+++ b/spec/models/shrine_spec.rb
@@ -89,9 +89,9 @@ RSpec.describe Shrine, type: :model do
     end
 
     it 'raises when an unexpected error occurs' do
-      allow(Shrine).to receive(:text_search_by_location_restriction).and_raise(PlaceApiRequestFailedError, "Google Places API request failed")
+      allow(Shrine).to receive(:text_search_by_location_restriction).and_raise(PlaceApiRequestFailedError.new("500"))
 
-      expect { Shrine.search_by_bounds(1, 2, 3, 4) }.to raise_error(PlaceApiRequestFailedError, "Google Places API request failed")
+      expect { Shrine.search_by_bounds(1, 2, 3, 4) }.to raise_error(PlaceApiRequestFailedError)
     end
   end
 
@@ -117,9 +117,9 @@ RSpec.describe Shrine, type: :model do
     end
 
     it 'raises when an unexpected error occurs' do
-      allow(Shrine).to receive(:text_search_by_location_bias).and_raise(PlaceApiRequestFailedError, "Google Places API request failed")
+      allow(Shrine).to receive(:text_search_by_location_bias).and_raise(PlaceApiRequestFailedError.new("500"))
 
-      expect { Shrine.search_by_location(1, 2) }.to raise_error(PlaceApiRequestFailedError, "Google Places API request failed")
+      expect { Shrine.search_by_location(1, 2) }.to raise_error(PlaceApiRequestFailedError)
     end
   end
 end

--- a/spec/models/shrine_spec.rb
+++ b/spec/models/shrine_spec.rb
@@ -89,9 +89,9 @@ RSpec.describe Shrine, type: :model do
     end
 
     it 'raises when an unexpected error occurs' do
-      allow(Shrine).to receive(:text_search_by_location_restriction).and_raise(StandardError, "api down")
+      allow(Shrine).to receive(:text_search_by_location_restriction).and_raise(PlaceApiRequestFailedError, "Google Places API request failed")
 
-      expect { Shrine.search_by_bounds(1, 2, 3, 4) }.to raise_error(StandardError, "api down")
+      expect { Shrine.search_by_bounds(1, 2, 3, 4) }.to raise_error(PlaceApiRequestFailedError, "Google Places API request failed")
     end
   end
 
@@ -117,9 +117,9 @@ RSpec.describe Shrine, type: :model do
     end
 
     it 'raises when an unexpected error occurs' do
-      allow(Shrine).to receive(:text_search_by_location_bias).and_raise(StandardError, "api down")
+      allow(Shrine).to receive(:text_search_by_location_bias).and_raise(PlaceApiRequestFailedError, "Google Places API request failed")
 
-      expect { Shrine.search_by_location(1, 2) }.to raise_error(StandardError, "api down")
+      expect { Shrine.search_by_location(1, 2) }.to raise_error(PlaceApiRequestFailedError, "Google Places API request failed")
     end
   end
 end


### PR DESCRIPTION
## 概要

`PlaceApi` concern（`app/models/concerns/place_api.rb`）の `text_search_by_location_restriction` / `text_search_by_location_bias` が、Google Places API のレスポンスが200以外（クォータ超過・5xx等の障害）の場合と、引数不足の場合の両方で同じ `nil` を返しており、呼び出し元 `Shrine.search_by_bounds` / `search_by_location` が `nil` を「バリデーションエラー」とみなして `false`（→400 "invalid params"）を返していました。実態がGoogle API障害でも、ユーザーには「入力に誤りがあります」という誤った400が返る問題がありました。

closes #271
関連: #265

### 対応内容

- `app/errors/place_api_request_failed_error.rb`（新規）: `PlaceApiRequestFailedError < StandardError` を定義。Google側のHTTPステータスコードを `status_code` として保持し、障害調査時にログから追えるようにした
- `app/models/concerns/place_api.rb`: 非200レスポンス時に `nil` を返す代わりに `PlaceApiRequestFailedError` を raise するよう変更。あわせて2メソッドに重複していたHTTPリクエスト構築・レスポンス判定ロジックを private メソッド `perform_search_text_request` に抽出し、URIを定数化。デバッグ用のコメントアウト行を削除
- `app/models/shrine.rb`: 変更なし。引数不足（`nil`）時は従来通り `false` を返し、`PlaceApiRequestFailedError` は rescue せず、既存の `Api::ExceptionHandler`（`rescue_from StandardError, with: :render_500`）に伝播させる。ログ出力もこの既存機構で自動的に行われる

## 確認方法

1. `docker-compose exec web bundle exec rspec spec/models/concerns/place_api_spec.rb spec/models/shrine_spec.rb` を実行し、32件全てパスすることを確認してください
2. `docker-compose exec web bundle exec rspec` でバックエンド全体（231件）が回帰していないことを確認してください

## 影響範囲

- `Shrine.search_by_bounds` / `Shrine.search_by_location`（神社検索API）の異常系レスポンスが変わります。Google Places APIが障害を返した場合、これまでの400（invalid params）から500（Internal Server Error）に変わります
- 引数不足時の挙動（400）は変更ありません

## チェックリスト

- [x] ユニットテストを追加した（`spec/models/concerns/place_api_spec.rb` 新規、`spec/models/shrine_spec.rb` 更新）
- [x] 既存テストスイート（231件）が全てパスすることを確認した

## コメント

Google Places API が429（クォータ超過）を返した場合も、現状は他の5xxと同様に500に丸めています。自アプリの日次利用上限用に既存の `TooManyRequestsError`（→429応答）がありますが、Google側の429と意味が異なるため、今回は区別せず500に統一しています。この設計判断について異論があればコメントください。