### PR TITLE
fix: 解答済み算額のFK違反を解消（FixedInput#answer_resultsをdependent: :destroyに）

### DIFF
--- a/app/models/fixed_input.rb
+++ b/app/models/fixed_input.rb
@@ -1,7 +1,7 @@
 class FixedInput < ApplicationRecord
   belongs_to :sangaku
 
-  has_many :answer_results
+  has_many :answer_results, dependent: :destroy
 
   validates :content, presence: true, length: { maximum: 65_535 }
   validates :content, uniqueness: { scope: :sangaku_id }

--- a/spec/models/fixed_input_spec.rb
+++ b/spec/models/fixed_input_spec.rb
@@ -35,4 +35,18 @@ RSpec.describe FixedInput, type: :model do
       expect { input.update(content: 'updated_content') }.to have_enqueued_job(GenerateExpectedOutputJob)
     end
   end
+
+  describe '#destroy' do
+    it 'destroys associated answer_results instead of raising a foreign key violation' do
+      sangaku = create(:sangaku)
+      fixed_input = create(:fixed_input, sangaku: sangaku)
+      sangaku.reload
+      user_sangaku_save = create(:user_sangaku_save, sangaku: sangaku)
+      answer = create(:answer, user_sangaku_save: user_sangaku_save)
+      answer_result = answer.answer_results.find_by(fixed_input: fixed_input)
+
+      expect { fixed_input.destroy! }.not_to raise_error
+      expect(AnswerResult.exists?(answer_result.id)).to eq false
+    end
+  end
 end

--- a/spec/models/sangaku_spec.rb
+++ b/spec/models/sangaku_spec.rb
@@ -27,7 +27,31 @@ RSpec.describe Sangaku, type: :model do
     end
   end
 
+  describe '#destroy' do
+    it 'destroys the sangaku without raising a foreign key violation when a fixed_input has answer_results' do
+      sangaku = create(:sangaku)
+      fixed_input = create(:fixed_input, sangaku: sangaku)
+      sangaku.reload
+      user_sangaku_save = create(:user_sangaku_save, sangaku: sangaku)
+      create(:answer, user_sangaku_save: user_sangaku_save)
+
+      expect { sangaku.destroy! }.not_to raise_error
+      expect(FixedInput.exists?(fixed_input.id)).to eq false
+    end
+  end
+
   describe '#save_with_inputs' do
+    it 'removes a fixed_input that has answer_results without raising a foreign key violation' do
+      sangaku = create(:sangaku)
+      fixed_input = create(:fixed_input, sangaku: sangaku, content: "old_input")
+      sangaku.reload
+      user_sangaku_save = create(:user_sangaku_save, sangaku: sangaku)
+      create(:answer, user_sangaku_save: user_sangaku_save)
+
+      expect(sangaku.save_with_inputs([])).to eq true
+      expect(FixedInput.exists?(fixed_input.id)).to eq false
+    end
+
     it 'returns false when save! raises ActiveRecord::RecordInvalid' do
       sangaku = create(:sangaku)
       allow(sangaku).to receive(:save!).and_raise(ActiveRecord::RecordInvalid.new(sangaku))

--- a/spec/requests/api/v1/admin/sangakus_spec.rb
+++ b/spec/requests/api/v1/admin/sangakus_spec.rb
@@ -182,6 +182,21 @@ RSpec.describe "Api::V1::Admin::Sangakus", type: :request do
 
         expect(response).to have_http_status(:not_found)
       end
+
+      it "returns 200 and deletes the sangaku when a fixed_input has answer_results", openapi: false do
+        fixed_input = create(:fixed_input, sangaku: sangaku)
+        sangaku.reload
+        user_sangaku_save = create(:user_sangaku_save, sangaku: sangaku)
+        create(:answer, user_sangaku_save: user_sangaku_save)
+
+        authenticate_stub(admin_user)
+        expect {
+          delete api_v1_admin_sangaku_path(sangaku.id), headers: headers
+        }.to change(Sangaku, :count).by(-1)
+
+        expect(response).to have_http_status(:ok)
+        expect(FixedInput.exists?(fixed_input.id)).to eq false
+      end
     end
 
     context "as general user" do

--- a/spec/requests/api/v1/user/sangakus_spec.rb
+++ b/spec/requests/api/v1/user/sangakus_spec.rb
@@ -171,6 +171,24 @@ RSpec.describe "Api::V1::User::Sangakus", type: :request do
         expect(response).not_to be_successful
       end
     end
+
+    context "removing a fixed_input that has answer_results", openapi: false do
+      let!(:sangaku) { create(:sangaku, title: "before_changed", user: user) }
+      let!(:fixed_input) { create(:fixed_input, sangaku: sangaku, content: "old_input") }
+      let!(:user_sangaku_save) { sangaku.reload; create(:user_sangaku_save, sangaku: sangaku) }
+      let!(:answer) { create(:answer, user_sangaku_save: user_sangaku_save) }
+      let(:params) { { sangaku: attributes_for(:sangaku, title: "changed_title"), fixed_inputs: [] }.to_json }
+      let(:http_request) { patch api_v1_user_sangaku_path(sangaku.id), headers:, params: }
+
+      it "success to update sangaku" do
+        authenticate_stub(user)
+
+        http_request
+        expect(response).to have_http_status(:ok)
+        expect(response).to be_successful
+        expect(FixedInput.exists?(fixed_input.id)).to eq false
+      end
+    end
   end
 
   describe "DELETE /sangakus/[id]" do
@@ -180,6 +198,24 @@ RSpec.describe "Api::V1::User::Sangakus", type: :request do
 
     context "with with_accesstoken" do
       let!(:sangaku) { create(:sangaku, user:) }
+      let(:http_request) { delete api_v1_user_sangaku_path(sangaku.id), headers: }
+
+      it "return sangaku in json format" do
+        authenticate_stub(user)
+
+        expect {
+          http_request
+        }.to change(Sangaku, :count).by(-1)
+        expect(response).to have_http_status(:ok)
+        expect(response).to be_successful
+      end
+    end
+
+    context "with a fixed_input that has answer_results", openapi: false do
+      let!(:sangaku) { create(:sangaku, user:) }
+      let!(:fixed_input) { create(:fixed_input, sangaku: sangaku) }
+      let!(:user_sangaku_save) { sangaku.reload; create(:user_sangaku_save, sangaku: sangaku) }
+      let!(:answer) { create(:answer, user_sangaku_save: user_sangaku_save) }
       let(:http_request) { delete api_v1_user_sangaku_path(sangaku.id), headers: }
 
       it "return sangaku in json format" do


### PR DESCRIPTION
## 概要

issue #279 の対応です。解答（AnswerResult）が紐づいた算額に対して、出題者・adminが以下2つの操作を行うと `ActiveRecord::InvalidForeignKey` が発生し500エラーになっていました。

1. 算額の削除（`Sangaku#destroy!`）
2. 固定入力の削除を伴う編集（`Sangaku#save_with_inputs`）

原因は `FixedInput#answer_results` に依存関係（`dependent`）が指定されておらず、`fixed_input` 削除時に紐づく `answer_results` がDB外部キー制約に引っかかっていたためです。`FixedInput` の `has_many :answer_results` に `dependent: :destroy` を指定し、`fixed_input` 削除時に紐づく `answer_results` も道連れに削除することでFK違反を解消しました。

closes #279

## 確認方法

1. 算額を作成し、固定入力を追加する
2. 別ユーザーでその算額に解答する（`answer_results` が作成される）
3. 出題者またはadminとしてその算額を削除する → 200で削除できることを確認（修正前は500）
4. 別の算額で同様に解答済みの状態を作り、固定入力を削除する編集（PATCH）を行う → 200で更新できることを確認（修正前は500）

または以下で回帰テストを実行してください。

```bash
docker-compose exec web bundle exec rspec spec/models/fixed_input_spec.rb spec/models/sangaku_spec.rb spec/requests/api/v1/user/sangakus_spec.rb spec/requests/api/v1/admin/sangakus_spec.rb
```

## 影響範囲

- `FixedInput` が削除される際、紐づく `AnswerResult`（採点結果）も物理削除されるようになります。出題者が固定入力（テストケース）を削除すると、その入力に対する既存の採点結果（不正解だった履歴含む）も消えます。
- これに伴い、`app/controllers/api/v1/user/results_controller.rb` の正答率集計（`Answer.is_status`）や `AnswerSerializer` が返す結果件数が、固定入力削除後に事後的に変化し得ます（過去に不正解だった回答が、該当テストケース削除後に見かけ上「正解」扱いになり得ます）。
- DB外部キー制約（`fk_rails_23963639bb`）自体は変更していません（Railsレベルの `dependent: :destroy` のみで対応）。

## チェックリスト

- [x] ユニットテスト（モデルspec）を追加した
- [x] リクエストspecを追加した
- [x] Rubocopのチェックをパスした
- [ ] 必要なドキュメントを作成した

## コメント

上記の「影響範囲」に記載の通り、固定入力削除時に採点結果が消える挙動は意図した仕様変更です（issue #279 で合意済み）。UI側で正答率などの表示に違和感が出ないか、別途確認をお願いします。
