### PR TITLE
fix: 保存済み算額のanswered/before_answerフィルタとhas_one:answerのデータロスを修正 (#280)

### DIFF
--- a/app/controllers/api/v1/user/answers_controller.rb
+++ b/app/controllers/api/v1/user/answers_controller.rb
@@ -15,6 +15,8 @@ module Api
         else
           render_400(nil, answer.errors.messages)
         end
+      rescue Answer::AlreadyAnsweredError
+        render_error(409, "Conflict", "この算額にはすでに解答が存在します")
       end
 
       def show

--- a/app/controllers/api/v1/user/saved_sangakus_controller.rb
+++ b/app/controllers/api/v1/user/saved_sangakus_controller.rb
@@ -2,26 +2,13 @@ module Api
   module V1
     class User::SavedSangakusController < BaseController
       def index
-        if params[:type] == "answered"
-          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.left_joins(:answers).where.not(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user, :shrine))
-          render json: PublicSangakuSerializer.new(saved_sangakus).serializable_hash.to_json
-        elsif params[:type] == "before_answer"
-          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).search(search_params).includes(:fixed_inputs, :user, :shrine))
-          render json: PublicSangakuSerializer.new(saved_sangakus).serializable_hash.to_json
-        else
-          @pagy, saved_sangakus = pagy(current_user.saved_sangakus.includes(:fixed_inputs, :user, :shrine))
-          render json: PublicSangakuSerializer.new(saved_sangakus).serializable_hash.to_json
-        end
+        @pagy, saved_sangakus = pagy(index_scope.includes(:fixed_inputs, :user, :shrine))
+        render json: PublicSangakuSerializer.new(saved_sangakus).serializable_hash.to_json
       end
 
       def show
-        if params[:type] == "before_answer"
-          saved_sangaku = current_user.saved_sangakus.left_joins(:answers).where(answers: { id: nil }).find(params[:id])
-          render json: PublicSangakuSerializer.new(saved_sangaku).serializable_hash.to_json
-        else
-          saved_sangaku = current_user.saved_sangakus.find(params[:id])
-          render json: PublicSangakuSerializer.new(saved_sangaku).serializable_hash.to_json
-        end
+        saved_sangaku = show_scope.find(params[:id])
+        render json: PublicSangakuSerializer.new(saved_sangaku).serializable_hash.to_json
       end
 
       def answer
@@ -30,6 +17,25 @@ module Api
       end
 
       private
+
+      def index_scope
+        case params[:type]
+        when "answered"
+          Sangaku.where(id: current_user.user_sangaku_saves.answered.select(:sangaku_id)).search(search_params)
+        when "before_answer"
+          Sangaku.where(id: current_user.user_sangaku_saves.unanswered.select(:sangaku_id)).search(search_params)
+        else
+          current_user.saved_sangakus
+        end
+      end
+
+      def show_scope
+        if params[:type] == "before_answer"
+          Sangaku.where(id: current_user.user_sangaku_saves.unanswered.select(:sangaku_id))
+        else
+          current_user.saved_sangakus
+        end
+      end
 
       def search_params
         params.permit(:title, :difficulty)

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -8,7 +8,6 @@ class Answer < ApplicationRecord
   has_many :answer_results, dependent: :destroy
 
   validates :source, presence: true, length: { maximum: 65_535 }
-  validates :user_sangaku_save_id, uniqueness: true
 
   scope :is_status, ->(status) { where.not(id: AnswerResult.where.not(status:).select(:answer_id)) }
 

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,14 +1,25 @@
 class Answer < ApplicationRecord
+  class AlreadyAnsweredError < StandardError; end
+
   after_create :create_results
+  after_initialize :prevent_overwriting_existing_answer, if: :new_record?
 
   belongs_to :user_sangaku_save
   has_many :answer_results, dependent: :destroy
 
   validates :source, presence: true, length: { maximum: 65_535 }
+  validates :user_sangaku_save_id, uniqueness: true
 
   scope :is_status, ->(status) { where.not(id: AnswerResult.where.not(status:).select(:answer_id)) }
 
   private
+
+  def prevent_overwriting_existing_answer
+    return unless user_sangaku_save_id
+    return unless self.class.exists?(user_sangaku_save_id: user_sangaku_save_id)
+
+    raise AlreadyAnsweredError, "この算額にはすでに解答が存在します"
+  end
 
   def create_results
     inputs = user_sangaku_save.sangaku.fixed_inputs

--- a/app/models/user_sangaku_save.rb
+++ b/app/models/user_sangaku_save.rb
@@ -7,4 +7,5 @@ class UserSangakuSave < ApplicationRecord
   validates :sangaku_id, uniqueness: { scope: :user_id }
 
   scope :unanswered, -> { left_joins(:answer).where(answers: { id: nil }) }
+  scope :answered, -> { left_joins(:answer).where.not(answers: { id: nil }) }
 end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -13,5 +13,33 @@ RSpec.describe Answer, type: :model do
       expect(answer).to be_invalid
       expect(answer.errors[:source]).to eq [ "を入力してください" ]
     end
+
+    it "is invalid when user_sangaku_save_id is already taken" do
+      existing_answer = create(:answer)
+      another_answer = Answer.new(source: "test")
+      another_answer.user_sangaku_save_id = existing_answer.user_sangaku_save_id
+
+      expect(another_answer).to be_invalid
+      expect(another_answer.errors[:user_sangaku_save_id]).to eq [ "はすでに存在します" ]
+    end
+  end
+
+  describe "preventing overwriting an existing answer" do
+    let!(:user_sangaku_save) { create(:user_sangaku_save) }
+    let!(:existing_answer) { create(:answer, user_sangaku_save:) }
+
+    it "raises AlreadyAnsweredError when building another answer for the same user_sangaku_save" do
+      expect {
+        user_sangaku_save.build_answer(source: "new")
+      }.to raise_error(Answer::AlreadyAnsweredError)
+    end
+
+    it "does not delete the existing answer" do
+      expect {
+        user_sangaku_save.build_answer(source: "new")
+      }.to raise_error(Answer::AlreadyAnsweredError)
+
+      expect(Answer.exists?(existing_answer.id)).to be true
+    end
   end
 end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -14,13 +14,12 @@ RSpec.describe Answer, type: :model do
       expect(answer.errors[:source]).to eq [ "を入力してください" ]
     end
 
-    it "is invalid when user_sangaku_save_id is already taken" do
+    it "raises ActiveRecord::RecordNotUnique when user_sangaku_save_id duplicates at the database level" do
       existing_answer = create(:answer)
       another_answer = Answer.new(source: "test")
       another_answer.user_sangaku_save_id = existing_answer.user_sangaku_save_id
 
-      expect(another_answer).to be_invalid
-      expect(another_answer.errors[:user_sangaku_save_id]).to eq [ "はすでに存在します" ]
+      expect { another_answer.save }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 

--- a/spec/requests/api/v1/user/answer_spec.rb
+++ b/spec/requests/api/v1/user/answer_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe "Api::V1::User::Answers", type: :request do
         expect(body["errors"]).to eq [ [ "source", [ "を入力してください" ] ] ]
       end
     end
+
+    context "when the sangaku_save already has an answer", openapi: false do
+      let!(:existing_answer) { create(:answer, user_sangaku_save:) }
+      let(:params) { { answer: { source: "puts 'new answer'" } }.to_json }
+
+      it "returns 409 and does not delete the existing answer" do
+        authenticate_stub(user)
+
+        expect {
+          http_request
+        }.to change(Answer, :count).by(0)
+
+        expect(response).to have_http_status(409)
+        expect(Answer.exists?(existing_answer.id)).to be true
+      end
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/api/v1/user/saved_sangakus_spec.rb
+++ b/spec/requests/api/v1/user/saved_sangakus_spec.rb
@@ -35,6 +35,77 @@ RSpec.describe "Api::V1::User::SavedSangakus", type: :request, openapi: { tags: 
     end
   end
 
+  describe "GET /index with multiple users' answer status" do
+    let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
+    let(:http_request) { get api_v1_user_saved_sangakus_path, headers:, params: }
+
+    context "when another user has answered the same saved sangaku" do
+      let!(:user) { create(:user) }
+      let!(:other_user) { create(:user) }
+      let!(:author) { create(:user, nickname: "author") }
+      let!(:shrine) { create(:shrine) }
+      let!(:sangaku) { create(:sangaku, user: author, shrine:) }
+      let!(:user_save) { create(:user_sangaku_save, sangaku:, user: user) }
+      let!(:other_save) { create(:user_sangaku_save, sangaku:, user: other_user) }
+      let!(:other_answer) { create(:answer, user_sangaku_save: other_save) }
+
+      context "with type=before_answer" do
+        let(:params) { { type: "before_answer" } }
+
+        it "includes the sangaku since current_user has not answered it yet" do
+          authenticate_stub(user)
+          http_request
+
+          expect(body["data"].map { |d| d["id"] }).to include(sangaku.id.to_s)
+        end
+      end
+
+      context "with type=answered" do
+        let(:params) { { type: "answered" } }
+
+        it "does not include the sangaku since current_user has not answered it" do
+          authenticate_stub(user)
+          http_request
+
+          expect(body["data"].map { |d| d["id"] }).not_to include(sangaku.id.to_s)
+        end
+      end
+    end
+
+    context "when current_user has answered but another user has not" do
+      let!(:user) { create(:user) }
+      let!(:other_user) { create(:user) }
+      let!(:author) { create(:user, nickname: "author") }
+      let!(:shrine) { create(:shrine) }
+      let!(:sangaku) { create(:sangaku, user: author, shrine:) }
+      let!(:user_save) { create(:user_sangaku_save, sangaku:, user: user) }
+      let!(:user_answer) { create(:answer, user_sangaku_save: user_save) }
+      let!(:other_save) { create(:user_sangaku_save, sangaku:, user: other_user) }
+
+      context "with type=answered" do
+        let(:params) { { type: "answered" } }
+
+        it "includes the sangaku since current_user has answered it" do
+          authenticate_stub(user)
+          http_request
+
+          expect(body["data"].map { |d| d["id"] }).to include(sangaku.id.to_s)
+        end
+      end
+
+      context "with type=before_answer" do
+        let(:params) { { type: "before_answer" } }
+
+        it "does not include the sangaku since current_user has already answered it" do
+          authenticate_stub(user)
+          http_request
+
+          expect(body["data"].map { |d| d["id"] }).not_to include(sangaku.id.to_s)
+        end
+      end
+    end
+  end
+
   describe "GET /show" do
     let!(:user) { create(:user) }
     let!(:author) { create(:user, nickname: "author") }
@@ -59,6 +130,47 @@ RSpec.describe "Api::V1::User::SavedSangakus", type: :request, openapi: { tags: 
         http_request
 
         expect(body["data"]["attributes"].keys).not_to include("source")
+      end
+    end
+  end
+
+  describe "GET /show with multiple users' answer status" do
+    let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
+    let(:params) { { type: "before_answer" } }
+    let(:http_request) { get api_v1_user_saved_sangaku_path(sangaku.id), headers:, params: }
+
+    context "when another user has answered the same saved sangaku but current_user has not" do
+      let!(:user) { create(:user) }
+      let!(:other_user) { create(:user) }
+      let!(:author) { create(:user, nickname: "author") }
+      let!(:sangaku) { create(:sangaku, user: author) }
+      let!(:user_save) { create(:user_sangaku_save, sangaku:, user: user) }
+      let!(:other_save) { create(:user_sangaku_save, sangaku:, user: other_user) }
+      let!(:other_answer) { create(:answer, user_sangaku_save: other_save) }
+
+      it "returns the sangaku" do
+        authenticate_stub(user)
+        http_request
+
+        expect(response).to have_http_status(:ok)
+        expect(body["data"]["id"]).to eq sangaku.id.to_s
+      end
+    end
+
+    context "when current_user has already answered the saved sangaku" do
+      let!(:user) { create(:user) }
+      let!(:other_user) { create(:user) }
+      let!(:author) { create(:user, nickname: "author") }
+      let!(:sangaku) { create(:sangaku, user: author) }
+      let!(:user_save) { create(:user_sangaku_save, sangaku:, user: user) }
+      let!(:user_answer) { create(:answer, user_sangaku_save: user_save) }
+      let!(:other_save) { create(:user_sangaku_save, sangaku:, user: other_user) }
+
+      it "returns not found since current_user has already answered it" do
+        authenticate_stub(user)
+        http_request
+
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
## 概要

以下2件の不具合を修正しました。

1. **issue #280**: `saved_sangakus_controller.rb` の `index`（`answered`/`before_answer`）と `show`（`before_answer`）が `current_user.saved_sangakus.left_joins(:answers)` という書き方をしており、`user_sangaku_saves` テーブルを無条件に再結合してしまうため、他ユーザーの解答状態が混入していた（同じ算額を保存した別ユーザーの解答有無によって、自分の一覧の表示が誤る）。`current_user.user_sangaku_saves` 起点のクエリに書き換え、`UserSangakuSave` に `answered`/`unanswered` スコープを追加して対応。

2. **調査過程で発見した別の不具合**: `AnswersController#create` が `sangaku_save.build_answer(...)` を呼んでいるが、`has_one :answer` の `build_answer`（`build_association`）は `.save` を呼ぶ前の `build` 時点で既存の解答レコードを削除してしまう（Rails公式ドキュメントにも `association=` がこの挙動を持つことが明記されている）。同時リクエストで事前チェックをすり抜けた場合、先着ユーザーの解答（および紐づく `answer_results`）が跡形もなく消えるデータロスの脆弱性だったため、`after_initialize` コールバックで削除処理より先に重複を検知し例外で中断するよう対応。

## 確認方法

1. `bundle exec rspec` で全テストが通過することを確認（258 examples, 0 failures）
2. `bundle exec rubocop` で変更ファイルに指摘がないことを確認

## 影響範囲

- `app/controllers/api/v1/user/saved_sangakus_controller.rb`
- `app/models/user_sangaku_save.rb`
- `app/models/answer.rb`
- `app/controllers/api/v1/user/answers_controller.rb`
- 対応する spec ファイル一式

## チェックリスト

- [x] rspec をパスした
- [x] Rubocop のチェックをパスした
- [x] ユニットテスト・リクエストテストを追加した

## コメント

3コミットで構成しています。

- `24b04d7`: issue #280 本体の修正
- `e8ba718`: `build_answer` によるデータロス対策（issue #280 とは独立した問題として発見・対応）
- `2b87e92`: 上記対策で追加した `uniqueness` バリデーションが、レース時に本来返るべき409を400に劣化させてしまう問題の修正（既存の `rescue_from ActiveRecord::RecordNotUnique, with: :render_409` に一本化）

いずれもコードレビューエージェントによる検証を経ています。