### PR TITLE
fix: AnswerSerializerがerrorステータスをcorrectとして集計するバグを修正 (#281)

### DIFF
--- a/app/controllers/api/v1/user/results_controller.rb
+++ b/app/controllers/api/v1/user/results_controller.rb
@@ -5,8 +5,8 @@ module Api
         sangaku = current_user.sangakus.find(params[:sangaku_id])
 
         user_sangaku_save_count = sangaku.user_sangaku_saves.count
-        correct_count = sangaku.answers.is_status("correct").count
-        incorrect_count = sangaku.answers.is_status("incorrect").count
+        correct_count = sangaku.answers.status_correct.count
+        incorrect_count = sangaku.answers.status_incorrect.count
 
         render json: {
           data: {

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -9,7 +9,28 @@ class Answer < ApplicationRecord
 
   validates :source, presence: true, length: { maximum: 65_535 }
 
-  scope :is_status, ->(status) { where.not(id: AnswerResult.where.not(status:).select(:answer_id)) }
+  # 優先順位: pending（1件でもあれば） > incorrect（error を含む） > correct（全件correctのときのみ）
+  # #status（Rubyでの単一Answer判定）と同じ優先順位を表現している。変更時は両方揃えること。
+  # 整合性は spec/models/answer_spec.rb の特性テストで保証している。
+  scope :status_correct, -> { where.not(id: AnswerResult.where.not(status: "correct").select(:answer_id)) }
+  scope :status_incorrect, -> {
+    where.not(id: AnswerResult.where(status: "pending").select(:answer_id))
+      .where(id: AnswerResult.where.not(status: "correct").select(:answer_id))
+  }
+
+  # 優先順位: pending（1件でもあれば） > incorrect（error を含む） > correct（全件correctのときのみ）
+  # scope :status_correct / :status_incorrect（集計用SQL版）と同じ優先順位を表現している。変更時は両方揃えること。
+  def status
+    statuses = answer_results.map(&:status)
+
+    if statuses.include?("pending")
+      "pending"
+    elsif statuses.include?("incorrect") || statuses.include?("error")
+      "incorrect"
+    else
+      "correct"
+    end
+  end
 
   private
 

--- a/app/serializers/answer_serializer.rb
+++ b/app/serializers/answer_serializer.rb
@@ -2,9 +2,7 @@ class AnswerSerializer
   include JSONAPI::Serializer
   attributes :source
   attribute :status do |answer|
-    results = answer.answer_results.map(&:status)
-    results.include?("pending") ? "pending" :
-      results.include?("incorrect") ? "incorrect" : "correct"
+    answer.status
   end
   belongs_to :user_sangaku_save
   has_many :answer_results

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -41,4 +41,95 @@ RSpec.describe Answer, type: :model do
       expect(Answer.exists?(existing_answer.id)).to be true
     end
   end
+
+  describe "status calculation" do
+    let!(:author) { create(:user, nickname: "author") }
+    let!(:shrine) { create(:shrine) }
+    let!(:sangaku) { create(:sangaku, shrine:, user: author) }
+    let!(:fixed_input_1) { create(:fixed_input, sangaku:) }
+    let!(:fixed_input_2) { create(:fixed_input, sangaku:) }
+    let!(:user_sangaku_save) { create(:user_sangaku_save, sangaku: sangaku.reload) }
+    let!(:answer) { create(:answer, user_sangaku_save:) }
+
+    describe "#status" do
+      it "returns pending when pending and error are both present" do
+        answer.answer_results.first.update!(status: "error")
+        answer.answer_results.second.update!(status: "pending")
+
+        expect(answer.status).to eq "pending"
+      end
+
+      it "returns incorrect when incorrect and error are both present" do
+        answer.answer_results.first.update!(status: "incorrect")
+        answer.answer_results.second.update!(status: "error")
+
+        expect(answer.status).to eq "incorrect"
+      end
+
+      it "returns correct when all answer_results are correct" do
+        answer.answer_results.each { |result| result.update!(status: "correct") }
+
+        expect(answer.status).to eq "correct"
+      end
+    end
+
+    describe "status_correct / status_incorrect scopes" do
+      it "matches only correct when all results are correct" do
+        answer.answer_results.each { |result| result.update!(status: "correct") }
+
+        expect(Answer.status_correct).to include(answer)
+        expect(Answer.status_incorrect).not_to include(answer)
+      end
+
+      it "matches only incorrect when incorrect and error are mixed without pending" do
+        answer.answer_results.first.update!(status: "incorrect")
+        answer.answer_results.second.update!(status: "error")
+
+        expect(Answer.status_incorrect).to include(answer)
+        expect(Answer.status_correct).not_to include(answer)
+      end
+
+      it "matches incorrect when all results are error" do
+        answer.answer_results.each { |result| result.update!(status: "error") }
+
+        expect(Answer.status_incorrect).to include(answer)
+        expect(Answer.status_correct).not_to include(answer)
+      end
+
+      it "matches neither scope when all results are pending" do
+        answer.answer_results.each { |result| result.update!(status: "pending") }
+
+        expect(Answer.status_correct).not_to include(answer)
+        expect(Answer.status_incorrect).not_to include(answer)
+      end
+
+      it "matches neither scope when pending and correct are mixed" do
+        answer.answer_results.first.update!(status: "pending")
+        answer.answer_results.second.update!(status: "correct")
+
+        expect(Answer.status_correct).not_to include(answer)
+        expect(Answer.status_incorrect).not_to include(answer)
+      end
+    end
+
+    describe "consistency between #status and status_correct/status_incorrect scopes" do
+      [
+        { statuses: %w[pending pending],   expected: "pending" },
+        { statuses: %w[pending correct],   expected: "pending" },
+        { statuses: %w[pending error],     expected: "pending" },
+        { statuses: %w[correct correct],   expected: "correct" },
+        { statuses: %w[correct incorrect], expected: "incorrect" },
+        { statuses: %w[correct error],     expected: "incorrect" },
+        { statuses: %w[error error],       expected: "incorrect" }
+      ].each do |c|
+        it "#status と scope の該当が #{c[:statuses]} -> #{c[:expected]} で一致する" do
+          answer.answer_results.zip(c[:statuses]).each { |result, status| result.update!(status:) }
+
+          expect(answer.status).to eq c[:expected]
+          expect(Answer.status_correct.include?(answer)).to eq(c[:expected] == "correct")
+          expect(Answer.status_incorrect.include?(answer)).to eq(c[:expected] == "incorrect")
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/user/answer_spec.rb
+++ b/spec/requests/api/v1/user/answer_spec.rb
@@ -97,5 +97,17 @@ RSpec.describe "Api::V1::User::Answers", type: :request do
         expect(response).to have_http_status(401)
       end
     end
+
+    context "when all answer_results have error status", openapi: false do
+      before { answer.answer_results.update_all(status: "error") }
+
+      it "returns incorrect status instead of correct" do
+        authenticate_stub(user)
+        http_request
+
+        expect(response).to have_http_status(:ok)
+        expect(body["data"]["attributes"]["status"]).to eq "incorrect"
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/user/results_spec.rb
+++ b/spec/requests/api/v1/user/results_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe "Api::V1::User::Results", type: :request do
         expect(body["data"]["attributes"]["correct_count"]).to eq 1
         expect(body["data"]["attributes"]["incorrect_count"]).to eq 0
       end
+
+      it "counts an answer with all-error results as incorrect", openapi: false do
+        answer.answer_results.first.update!(status: "error")
+        authenticate_stub(user)
+
+        http_request
+        expect(response).to have_http_status(:ok)
+        expect(body["data"]["attributes"]["correct_count"]).to eq 0
+        expect(body["data"]["attributes"]["incorrect_count"]).to eq 1
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

close #281

`AnswerSerializer` の集計ロジックが `error` ステータス（PaizaIO障害でリトライ枯渇時にセットされる）を考慮しておらず、全 `answer_results` が `error` の場合に `pending` でも `incorrect` でもないため誤って `"correct"` と表示されてしまうバグを修正しました。

- `error` は独立したステータス値として公開せず `incorrect` に統合。優先順位は `pending`（1件でもあれば最優先）> `incorrect`（`incorrect` または `error` を含む）> `correct`（全件correctのときのみ）
- 判定ロジックを `Answer#status`（`AnswerSerializer` が使用、単一Answerの判定）と `Answer.status_correct` / `Answer.status_incorrect`（`ResultsController` が使用、集計用SQL scope）の2箇所に実装
- 既存の `is_status` scope は「全件一致」を要求する意味論だったため、全件errorや correct/incorrect 混在のAnswerが `ResultsController` の正解数・不正解数のどちらにもカウントされない不整合があった。今回これも解消（`status_correct`/`status_incorrect` に置き換え）
- ネストした三項演算子は `if`/`elsif` に書き直し

## 確認方法

1. 算額に解答し、`answer_results` の全レコードを `status: "error"` に更新する（PaizaIO障害でリトライ枯渇した状態を再現）
2. 解答結果画面（`GET /api/v1/user/answers/:id`）のレスポンスで `status` が `"correct"` ではなく `"incorrect"` になることを確認
3. 算額の成績画面（`GET /api/v1/user/sangakus/:sangaku_id/result`）で、上記のAnswerが `correct_count` ではなく `incorrect_count` にカウントされることを確認

## 影響範囲

- `AnswerSerializer` を経由する全APIレスポンス（解答詳細取得など）の `status` 値
- `ResultsController#show`（成績集計）の `correct_count` / `incorrect_count`
- DBスキーマ・マイグレーションの変更なし

## チェックリスト

- [x] RSpec全件パス（275 examples, 0 failures）
- [x] RuboCop パス（対象ファイル指摘なし）
- [x] ユニットテスト・リクエストテストを追加（`Answer#status`、`Answer.status_correct`/`status_incorrect` の優先順位ロジック網羅、両実装の整合性テストを含む）

## コメント

`Answer#status`（Ruby実装）と `Answer.status_correct`/`status_incorrect`（SQL scope実装）は同じ優先順位ロジックを別々に実装しています。用途が異なる（単一Answerの判定 vs 集計用フィルタ）ため意図的に分けていますが、将来どちらか一方だけ修正されて意味がズレるリスクがあるため、両者が常に一致することを保証する特性テストを `spec/models/answer_spec.rb` に追加しています。変更時は両方揃えてください。
