### PR TITLE
fix: 算額の重複保存時に500ではなく409を返すようにする

### DIFF
--- a/app/controllers/concerns/api/exception_handler.rb
+++ b/app/controllers/concerns/api/exception_handler.rb
@@ -6,6 +6,7 @@ module Api::ExceptionHandler
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
     rescue_from ActionController::ParameterMissing, with: :render_400
     rescue_from ActiveRecord::RecordNotUnique, with: :render_409
+    rescue_from ActiveRecord::RecordInvalid, with: :render_409
     rescue_from TooManyRequestsError, with: :render_429
   end
 

--- a/spec/requests/api/v1/sangaku_saves_spec.rb
+++ b/spec/requests/api/v1/sangaku_saves_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe "Api::V1::Sangakus", type: :request do
         expect(json["data"]["attributes"]).not_to have_key("source")
         expect(response.body).not_to include(sangaku.source)
       end
+
+      it "returns 409 when the sangaku is already saved" do
+        authenticate_stub(user)
+        http_request
+
+        expect {
+          # 実際のリクエストは毎回 DB から current_user を再取得するため、
+          # ここでも user を reload して同一Rubyオブジェクトの使い回しによる
+          # 誤ったキャッシュ挙動（no-op化）を避ける
+          authenticate_stub(User.find(user.id))
+          post api_v1_sangaku_save_path(sangaku.id), headers:
+        }.not_to change(user.saved_sangakus, :count)
+        expect(response).to have_http_status(:conflict)
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

算額の重複保存（ブックマーク）リクエストが500エラーになっていた不具合を修正しました（closes #282）。

`app/controllers/api/v1/sangaku_saves_controller.rb` の `current_user.add_saved_sangakus(sangaku)` は、`UserSangakuSave` の `validates :sangaku_id, uniqueness: { scope: :user_id }` に違反すると `ActiveRecord::RecordInvalid` を投げますが、`Api::ExceptionHandler` にこの例外が未登録だったため `StandardError` として500になっていました。

`rescue_from ActiveRecord::RecordInvalid, with: :render_409` を追加し、既存の `ActiveRecord::RecordNotUnique`（DBレベルのレースコンディション用）と同様に409 Conflictを返すようにしました。

保存ボタンの二重クリックで容易に再現する不具合でした。

## 確認方法

1. `docker-compose exec web bundle exec rspec spec/requests/api/v1/sangaku_saves_spec.rb spec/controllers/concerns/api/exception_handler_spec.rb` で新規テスト・既存テストがパスすることを確認
2. 同一算額に対して2回連続で `POST /api/v1/sangakus/:id/save` を実行し、1回目は200、2回目は409になることを確認

## 影響範囲

`Api::ExceptionHandler` を include する全コントローラーに影響しますが、`RecordInvalid` を409にマッピングするだけで、既存のコードベース内で `RecordInvalid` が発生しうる箇所（`Sangaku#save_with_inputs`/`#dedicate`、`Shrine.search_by_bounds`/`#search_by_location`）はいずれもメソッド内で既にrescue済みのため、他の挙動への影響はありません。

front側の `createAnswer`（解答API）の409エラーハンドリングは front#96 で別途対応予定です（本PRのスコープ外）。

## チェックリスト

- [x] ユニットテスト（request spec）を追加した
- [x] 全体テストスイート（276 examples, 0 failures, 1 pending）でデグレがないことを確認した
- [x] siderをパスした
- [x] Lint のチェックをパスした

## コメント

テスト実装時、以下2点でハマったため念のため共有します。

1. `let(:http_request) { post ... }` は `let` のため、同一example内で2回呼んでも2回目はメモ化された結果が返るだけで実際にはPOSTされません。2回目は明示的に `post api_v1_sangaku_save_path(...)` を直接呼ぶようにしています。
2. `authenticate_stub` ヘルパーは渡した `user` オブジェクトをそのままメモ化するため、同一Rubyオブジェクトを2回のリクエストで使い回すと `has_many :through` の内部キャッシュ（`build_through_record` の `@through_records[record.object_id]`）により2回目の保存処理が実際にはDBにアクセスせずno-opになり、意図せず200が返ってしまいました。本番では毎リクエストで `current_user` をDBから再取得するため問題になりませんが、テストでは `User.find(user.id)` で明示的に新しいUserオブジェクトを取得することで実際のリクエストの挙動を再現しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)