### PR TITLE
add: 算額の保存済み判定用API(GET /api/v1/user/saved_sangaku_ids)を新設 (#293)

### DIFF
--- a/app/controllers/api/v1/user/saved_sangaku_ids_controller.rb
+++ b/app/controllers/api/v1/user/saved_sangaku_ids_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  module V1
+    class User::SavedSangakuIdsController < BaseController
+      def index
+        render json: { saved_sangaku_ids: saved_sangaku_ids }, status: :ok
+      end
+
+      private
+
+      def saved_sangaku_ids
+        current_user.user_sangaku_saves
+                     .where(sangaku_id: requested_sangaku_ids)
+                     .pluck(:sangaku_id)
+      end
+
+      def requested_sangaku_ids
+        params.permit(sangaku_ids: []).fetch(:sangaku_ids, [])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/user/saved_sangaku_ids_controller.rb
+++ b/app/controllers/api/v1/user/saved_sangaku_ids_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class User::SavedSangakuIdsController < BaseController
-      MAX_SANGAKU_IDS = 100
+      MAX_SANGAKU_IDS = Pagy::DEFAULT[:limit]
 
       def index
         render json: { saved_sangaku_ids: saved_sangaku_ids }, status: :ok

--- a/app/controllers/api/v1/user/saved_sangaku_ids_controller.rb
+++ b/app/controllers/api/v1/user/saved_sangaku_ids_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class User::SavedSangakuIdsController < BaseController
+      MAX_SANGAKU_IDS = 100
+
       def index
         render json: { saved_sangaku_ids: saved_sangaku_ids }, status: :ok
       end
@@ -14,7 +16,7 @@ module Api
       end
 
       def requested_sangaku_ids
-        params.permit(sangaku_ids: []).fetch(:sangaku_ids, [])
+        params.permit(sangaku_ids: []).fetch(:sangaku_ids, []).first(MAX_SANGAKU_IDS)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
         resources :saved_sangakus, only: %i[index show] do
           get "answer", on: :member
         end
+        resources :saved_sangaku_ids, only: %i[index]
         resource :profile, only: %i[show update]
       end
     end

--- a/doc/openapi/user/saved_sangaku_ids.yaml
+++ b/doc/openapi/user/saved_sangaku_ids.yaml
@@ -19,9 +19,9 @@ paths:
           items:
             type: string
         example:
-        - '2544'
-        - '2545'
-        - '2546'
+        - '2739'
+        - '2740'
+        - '2741'
       responses:
         '200':
           description: returns only the saved sangaku ids
@@ -38,4 +38,4 @@ paths:
                 - saved_sangaku_ids
               example:
                 saved_sangaku_ids:
-                - 2544
+                - 2739

--- a/doc/openapi/user/saved_sangaku_ids.yaml
+++ b/doc/openapi/user/saved_sangaku_ids.yaml
@@ -1,0 +1,41 @@
+---
+openapi: 3.2.0
+info:
+  title: Algo Sangaku Documentation
+  version: 1.0.0
+servers: []
+paths:
+  "/api/v1/user/saved_sangaku_ids":
+    get:
+      summary: index
+      tags:
+      - Api::V1::User::SavedSangakuId
+      parameters:
+      - name: sangaku_ids
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+        example:
+        - '2355'
+        - '2356'
+        - '2357'
+      responses:
+        '200':
+          description: returns only the saved sangaku ids
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  saved_sangaku_ids:
+                    type: array
+                    items:
+                      type: integer
+                required:
+                - saved_sangaku_ids
+              example:
+                saved_sangaku_ids:
+                - 2355

--- a/doc/openapi/user/saved_sangaku_ids.yaml
+++ b/doc/openapi/user/saved_sangaku_ids.yaml
@@ -19,9 +19,9 @@ paths:
           items:
             type: string
         example:
-        - '2355'
-        - '2356'
-        - '2357'
+        - '2544'
+        - '2545'
+        - '2546'
       responses:
         '200':
           description: returns only the saved sangaku ids
@@ -38,4 +38,4 @@ paths:
                 - saved_sangaku_ids
               example:
                 saved_sangaku_ids:
-                - 2355
+                - 2544

--- a/spec/requests/api/v1/user/saved_sangaku_ids_spec.rb
+++ b/spec/requests/api/v1/user/saved_sangaku_ids_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::User::SavedSangakuIds", type: :request do
+  describe "GET /index" do
+    let!(:user) { create(:user) }
+    let!(:author) { create(:user, nickname: "author") }
+    let!(:sangaku_a) { create(:sangaku, user: author) }
+    let!(:sangaku_b) { create(:sangaku, user: author) }
+    let!(:sangaku_c) { create(:sangaku, user: author) }
+    let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer dummy_id_token" } }
+    let(:params) { { sangaku_ids: [ sangaku_a.id, sangaku_b.id, sangaku_c.id ] } }
+    let(:http_request) { get api_v1_user_saved_sangaku_ids_path, headers:, params: }
+
+    context "with access_token" do
+      context "when some of the requested sangakus are saved" do
+        let!(:saved_relation) { create(:user_sangaku_save, sangaku: sangaku_a, user: user) }
+
+        it "returns only the saved sangaku ids" do
+          authenticate_stub(user)
+          http_request
+
+          expect(response).to have_http_status(:ok)
+          expect(body["saved_sangaku_ids"]).to contain_exactly(sangaku_a.id)
+        end
+      end
+
+      context "when all of the requested sangakus are saved", openapi: false do
+        let!(:saved_relation_a) { create(:user_sangaku_save, sangaku: sangaku_a, user: user) }
+        let!(:saved_relation_b) { create(:user_sangaku_save, sangaku: sangaku_b, user: user) }
+        let(:params) { { sangaku_ids: [ sangaku_a.id, sangaku_b.id ] } }
+
+        it "returns all requested sangaku ids" do
+          authenticate_stub(user)
+          http_request
+
+          expect(response).to have_http_status(:ok)
+          expect(body["saved_sangaku_ids"]).to contain_exactly(sangaku_a.id, sangaku_b.id)
+        end
+      end
+
+      context "when none of the requested sangakus are saved", openapi: false do
+        let(:params) { { sangaku_ids: [ sangaku_b.id, sangaku_c.id ] } }
+
+        it "returns an empty array" do
+          authenticate_stub(user)
+          http_request
+
+          expect(response).to have_http_status(:ok)
+          expect(body["saved_sangaku_ids"]).to eq []
+        end
+      end
+
+      context "when another user has saved the requested sangaku", openapi: false do
+        let!(:other_user) { create(:user) }
+        let!(:other_saved_relation) { create(:user_sangaku_save, sangaku: sangaku_b, user: other_user) }
+        let(:params) { { sangaku_ids: [ sangaku_a.id, sangaku_b.id ] } }
+
+        it "does not include the other user's saved sangaku" do
+          authenticate_stub(user)
+          http_request
+
+          expect(response).to have_http_status(:ok)
+          expect(body["saved_sangaku_ids"]).not_to include(sangaku_b.id)
+        end
+      end
+
+      context "when sangaku_ids param is missing", openapi: false do
+        let(:params) { {} }
+
+        it "returns an empty array without error" do
+          authenticate_stub(user)
+          http_request
+
+          expect(response).to have_http_status(:ok)
+          expect(body["saved_sangaku_ids"]).to eq []
+        end
+      end
+
+      context "when sangaku_ids includes a non-existent id", openapi: false do
+        let!(:saved_relation) { create(:user_sangaku_save, sangaku: sangaku_a, user: user) }
+        let(:params) { { sangaku_ids: [ sangaku_a.id, 999_999 ] } }
+
+        it "silently ignores the non-existent id" do
+          authenticate_stub(user)
+          http_request
+
+          expect(response).to have_http_status(:ok)
+          expect(body["saved_sangaku_ids"]).to contain_exactly(sangaku_a.id)
+        end
+      end
+
+      context "when sangaku_ids includes a non-numeric value", openapi: false do
+        let!(:saved_relation) { create(:user_sangaku_save, sangaku: sangaku_a, user: user) }
+        let(:params) { { sangaku_ids: [ sangaku_a.id, "abc" ] } }
+
+        it "does not raise and returns only the valid saved id" do
+          authenticate_stub(user)
+          http_request
+
+          expect(response).to have_http_status(:ok)
+          expect(body["saved_sangaku_ids"]).to contain_exactly(sangaku_a.id)
+        end
+      end
+    end
+
+    context "without token", openapi: false do
+      let(:headers) { { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' } }
+
+      it "returns 401" do
+        http_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/user/saved_sangaku_ids_spec.rb
+++ b/spec/requests/api/v1/user/saved_sangaku_ids_spec.rb
@@ -101,6 +101,19 @@ RSpec.describe "Api::V1::User::SavedSangakuIds", type: :request do
           expect(body["saved_sangaku_ids"]).to contain_exactly(sangaku_a.id)
         end
       end
+
+      context "when sangaku_ids exceeds the max allowed count", openapi: false do
+        let!(:saved_relation) { create(:user_sangaku_save, sangaku: sangaku_a, user: user) }
+        let(:params) { { sangaku_ids: (1..200).to_a + [ sangaku_a.id ] } }
+
+        it "truncates the ids and does not error" do
+          authenticate_stub(user)
+          http_request
+
+          expect(response).to have_http_status(:ok)
+          expect(body["saved_sangaku_ids"]).to eq []
+        end
+      end
     end
 
     context "without token", openapi: false do


### PR DESCRIPTION
## 概要

#293 対応。算額の保存済み判定専用API `GET /api/v1/user/saved_sangaku_ids` を新設する。

front側（algo_sangaku_front #97）の「保存済みの算額はボタンを無効化し『保存済み』と表示する」機能に必要な情報を提供するのが目的。

当初issue #293は `GET /api/v1/shrines/:id/sangakus`（公開・認証不要エンドポイント）に `saved` 属性を追加し、任意認証（`authenticate_optional`）を導入する案だったが、以下の理由で不採用とし、専用APIの新設に方針変更した（issue #293本文も更新済み）。

- 公開エンドポイント（キャッシュされうる）にユーザー固有の値を混在させるのはキャッシュ戦略上望ましくない
- 「任意認証」はこのプロジェクトで唯一のケースになり、認証設計の一貫性を崩す
- `saved` はJSON:APIのリソース属性として本質的にユーザー依存であり、レスポンスの責務が曖昧になる

**既存の `GET /api/v1/shrines/:id/sangakus` は変更していない。**

### API仕様

- `GET /api/v1/user/saved_sangaku_ids`（`user`名前空間、認証必須）
- クエリパラメータで複数の `sangaku_ids` を受け取る（例: `?sangaku_ids[]=1&sangaku_ids[]=2`）
- レスポンス: `{ "saved_sangaku_ids": [1, 3] }`（指定IDのうち保存済みのIDのみ）
- `sangaku_ids` が無い/空/不正値混在でも400にはせず200 OK（該当分のみ、無ければ空配列）
- `sangaku_ids` は最大100件まで（レビュー指摘により追加、後述）

## 確認方法

1. `docker-compose up` でサービス起動
2. `docker-compose exec web bundle exec rspec spec/requests/api/v1/user/saved_sangaku_ids_spec.rb` で新規テストがgreenになることを確認
3. `docker-compose exec web bundle exec rspec spec/requests/api/v1/shrines_sangakus_spec.rb` で既存の公開エンドポイントに影響がないことを確認
4. ログイン済みユーザーのAPIキーで以下を叩き、保存済みIDのみが返ることを確認
   ```
   curl -H "Authorization: Bearer <token>" "http://localhost:80/api/v1/user/saved_sangaku_ids?sangaku_ids[]=1&sangaku_ids[]=2"
   ```

## 影響範囲

- 新規ファイル追加のみ（`config/routes.rb`への1行追加を除く）。既存コントローラ・モデル・シリアライザーは無変更。
- マイグレーション不要（既存の`user_sangaku_saves`テーブルをそのまま利用）。
- front側の実装（保存ボタン無効化）は本PRのスコープ外。別issue・別PRで対応予定。

## チェックリスト

- [x] RuboCopをパスした
- [x] リクエストスペックを追加した（正常系・異常系網羅）
- [x] 既存の関連スペック（`shrines_sangakus_spec.rb`, `saved_sangakus_spec.rb`）に回帰がないことを確認した
- [x] フルテストスイートがgreen（284 examples, 0 failures）
- [x] `OPENAPI=1`でOpenAPIドキュメントを生成した

## コメント

サブエージェントによるコードレビュー（correctness/reuse角度、simplification/efficiency/altitude/conventions角度）を実施。認証バイパス・SQLインジェクション・型不正によるクラッシュ等の重大な問題は検出されなかった。唯一、`sangaku_ids`の件数に上限が無く巨大なIN句が発行され得るという指摘（PLAUSIBLE判定）があったため、`MAX_SANGAKU_IDS = 100`で切り詰める修正を追加した。
