### PR TITLE
fix: ECSデプロイのトリガーをworkflow_dispatchに変更

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -1,11 +1,12 @@
 name: ECS deploy
 
 on:
-  pull_request:
-    branches: [main]
-    types: [closed]
-
   workflow_dispatch:
+    inputs:
+      sha:
+        description: "デプロイ対象の40桁フルコミットSHA（backリポジトリのコミット）"
+        required: true
+        type: string
 
 permissions:
   id-token: write   # OIDC トークン取得に必要
@@ -13,12 +14,38 @@ permissions:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
-      - name: Checkout
+      # main の全履歴を取得する（inputs.sha 自体は fetch しない）
+      - name: Checkout main
         uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      # inputs.sha の形式検証 + main 到達可能性検証（fork由来の未マージコミットを拒否）
+      - name: Validate and checkout deploy target sha
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          if ! printf '%s' "$INPUT_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "ERROR: sha は40桁の小文字16進数（フルコミットSHA）を指定してください" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$INPUT_SHA" origin/main; then
+            echo "ERROR: $INPUT_SHA は origin/main の履歴に含まれていません" >&2
+            exit 1
+          fi
+          git checkout --detach "$INPUT_SHA"
+
+      - name: Compute short sha
+        id: sha
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: echo "short=${INPUT_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       # arm64 クロスビルドに必要な QEMU・Buildx のセットアップ
       - name: Set up QEMU
@@ -43,22 +70,18 @@ jobs:
       - name: Build and push Rails image
         env:
           ECR_RAILS_URL: ${{ secrets.ECR_RAILS_URL }}
-          IMAGE_TAG: ${{ github.sha }}
+          SHORT_SHA: ${{ steps.sha.outputs.short }}
         run: |
-          SHORT_SHA="${IMAGE_TAG::7}"
-          docker build --platform linux/arm64 --build-arg RAILS_ENV=production -t "$ECR_RAILS_URL:latest" -t "$ECR_RAILS_URL:$SHORT_SHA" .
-          docker push "$ECR_RAILS_URL:latest"
+          docker build --platform linux/arm64 --build-arg RAILS_ENV=production -t "$ECR_RAILS_URL:$SHORT_SHA" .
           docker push "$ECR_RAILS_URL:$SHORT_SHA"
 
       # nginx イメージをビルド & push
       - name: Build and push nginx image
         env:
           ECR_NGINX_URL: ${{ secrets.ECR_NGINX_URL }}
-          IMAGE_TAG: ${{ github.sha }}
+          SHORT_SHA: ${{ steps.sha.outputs.short }}
         run: |
-          SHORT_SHA="${IMAGE_TAG::7}"
-          docker build --platform linux/arm64 -f nginx_docker_prod/Dockerfile -t "$ECR_NGINX_URL:latest" -t "$ECR_NGINX_URL:$SHORT_SHA" nginx_docker_prod/
-          docker push "$ECR_NGINX_URL:latest"
+          docker build --platform linux/arm64 -f nginx_docker_prod/Dockerfile -t "$ECR_NGINX_URL:$SHORT_SHA" nginx_docker_prod/
           docker push "$ECR_NGINX_URL:$SHORT_SHA"
 
       # 新しいイメージタグを含むタスク定義リビジョンを登録
@@ -67,13 +90,11 @@ jobs:
         env:
           ECR_RAILS_URL: ${{ secrets.ECR_RAILS_URL }}
           ECR_NGINX_URL: ${{ secrets.ECR_NGINX_URL }}
-          IMAGE_TAG: ${{ github.sha }}
+          SHORT_SHA: ${{ steps.sha.outputs.short }}
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
           ECS_SERVICE: ${{ secrets.ECS_SERVICE_NAME }}
           TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY }}
         run: |
-          SHORT_SHA="${IMAGE_TAG::7}"
-
           # 現在のタスク定義を取得
           TASK_DEF=$(aws ecs describe-task-definition \
             --task-definition "$TASK_FAMILY" \
@@ -112,11 +133,12 @@ jobs:
         env:
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
           ECS_SERVICE: ${{ secrets.ECS_SERVICE_NAME }}
+          TASK_DEF_ARN: ${{ steps.register-task-def.outputs.task_def_arn }}
         run: |
           aws ecs update-service \
             --cluster "$ECS_CLUSTER" \
             --service "$ECS_SERVICE" \
-            --task-definition "${{ steps.register-task-def.outputs.task_def_arn }}" \
+            --task-definition "$TASK_DEF_ARN" \
             --force-new-deployment
 
           echo "Waiting for service to stabilize..."


### PR DESCRIPTION
## 概要

closes #296

親issue（Alnoir-0011/algo_sangaku#38）の一部として、親リポジトリの `main` 更新（PRマージ）を本番デプロイの唯一のトリガーにする設計に合わせ、`autodeploy.yml`（ECS deploy）のトリガーを backリポジトリ自身の `main` への PR マージから、親リポジトリからの `workflow_dispatch(sha=...)` リモート起動のみに変更する。

トリガー変更に伴い、これまでGitHub側が保証していた「mainにマージ済みのコミットのみがデプロイされる」という制約が失われるため、レビューで指摘された以下のセキュリティ対応も合わせて実施した。

- `inputs.sha` の40桁hex形式検証 + `git merge-base --is-ancestor` による main 到達可能性検証（fork由来の未マージコミットを拒否する）
- `environment: production` の宣言
- ECR `latest` タグ運用の廃止（タスク定義は常に `SHORT_SHA` のみ参照しており不要。MUTABLEタグの無条件上書きリスクがあった）
- `SHORT_SHA` 計算の一元化、`run:` への式直接展開の解消、`checkout` への `persist-credentials: false` 追加

なお、以下は今回のスコープ外として別issue化する想定（チームで方針合意の上、別途対応）:
- GitHub Environments の実体作成・必須レビュアー設定・`main` ブランチ保護（`environment: production` の宣言のみ今回実施）
- IAM OIDC信頼ポリシー（`terraform/iam.tf`）の `sub` 条件をワイルドカードから絞り込む対応

## 確認方法

1. マージ後、`gh workflow run autodeploy.yml -f sha=<mainの現行フルコミットSHA>` で正常にECSデプロイが完了することを確認する
2. 異常系として、存在しないSHA・ブランチ名・短縮SHA・空文字を `-f sha=...` に指定した場合、`Validate and checkout deploy target sha` ステップで意図通り失敗することを確認する（AWS認証より前の段階で弾かれること）
3. デプロイ後、ECRに `latest` タグが新規作成されていないこと、`SHORT_SHA` タグのみが作成されていることを確認する

## 影響範囲

- `back/.github/workflows/autodeploy.yml` のみ変更（他のワークフロー `ci.yml` や Terraform には影響なし）
- 本PRマージ後、backリポジトリ自身の `main` へのPRマージでは本番ECSへのデプロイが実行されなくなる。本番反映には親リポジトリでのsubmoduleポインタ更新PRのマージ（`workflow_dispatch` 経由の呼び出し）が必須になる運用変更を伴う

## チェックリスト

- [x] YAML構文チェック（`ruby -ryaml`）
- [x] `github.sha` / `pull_request` トリガー / `latest` タグ参照が残っていないことを確認
- [x] shaバリデーションロジック（正常系・ブランチ名・空文字・シェルメタ文字・大文字混入・桁数違い・未fetchのSHA）をローカルのbashで実行して動作確認
- [ ] 実際の `workflow_dispatch` 実行によるECS本番デプロイの動作確認（本PRのスコープ外、マージ後に別途実施）

## コメント

- code-reviewer / security-reviewer によるレビューを実施し、指摘のうちワークフローファイル内で完結する項目（sha検証、latestタグ廃止、環境変数統一等）を反映済み。GitHub Environments実体設定・IAM信頼ポリシー変更は環境変更を伴うため、対応要否を含めて別途相談したい。