### PR TITLE
fix: GitHub OIDC信頼ポリシーをproduction Environment限定に絞り込む

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -127,9 +127,9 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
       values   = ["sts.amazonaws.com"]
     }
     condition {
-      test     = "StringLike"
+      test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:${var.github_repo}:*"]
+      values   = ["repo:${var.github_repo}:environment:production"]
     }
   }
 }


### PR DESCRIPTION
## 概要

closes #301

autodeploy.ymlのトリガーをworkflow_dispatchに変更した際のセキュリティレビュー（back#296）で、IAM OIDC信頼ポリシーの`sub`条件が`repo:<org>/<repo>:*`という全ワイルドカードのため、environment・ブランチを問わず本リポジトリのActions実行権限を持つ任意のワークフローが本番AWSデプロイ用IAMロール（`ecr:PutImage` / `ecs:UpdateService` / `iam:PassRole`等）をAssumeRoleできてしまう問題が判明した。

`autodeploy.yml`の`deploy`ジョブが`environment: production`を宣言していることを利用し、`terraform/iam.tf`の信頼ポリシー条件を`StringLike`（ワイルドカード）から`StringEquals`（`repo:<org>/<repo>:environment:production`）に絞り込んだ。

GitHub Environment側のRequired reviewer（back#300）と合わせた二重防御になる:
- GitHub側: `environment: production`を参照するジョブは、承認されるまで実行自体がブロックされる
- AWS側（本PR）: `environment: production`を宣言していないジョブは、正しい`sub`にならずAssumeRole自体が拒否される

## 確認方法

1. `terraform plan` で意図した差分（`aws_iam_role.github_actions_oidc`のみ変更、0 to add, 1 to change, 0 to destroy）であることを確認済み
2. `terraform apply` 実行済み。`aws iam get-role --role-name algo-sangaku-github-actions-role` でAWS上に条件が反映されていることを確認済み
3. マージ後、`workflow_dispatch` を実行し、`Configure AWS credentials` ステップでAssumeRoleが引き続き成功することを確認する（`environment: production`経由のため成功するはず）

## 影響範囲

- `back/terraform/iam.tf` のみ変更（他のTerraformリソース・ワークフローファイルへの影響なし）
- 今後、この本番デプロイ用IAMロールを使う新規ワークフローを追加する場合、ジョブに必ず `environment: production` を宣言する必要がある（宣言しないと`AccessDenied`でAssumeRoleに失敗する）

## チェックリスト

- [x] `terraform plan` で意図した差分のみであることを確認
- [x] `terraform apply` 実行、AWS上への反映を `aws iam get-role` で確認
- [ ] 実際の `workflow_dispatch` 実行によるAssumeRole成功の確認（マージ後に別途実施）

## コメント

- back#296のセキュリティレビュー・back#300（Environment Required reviewer整備）と対になる対応です。iam.tf変更は本番AWS環境（IAMロールの信頼ポリシー）に直接影響するため、事前に `terraform plan` の差分をレビューした上でapplyを実施しました。