### PR TITLE
fix: autodeploy.ymlのconcurrency追加とderegister権限不足を修正

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -12,9 +12,14 @@ permissions:
   id-token: write   # OIDC トークン取得に必要
   contents: read
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     environment: production
 
     steps:
@@ -167,13 +172,20 @@ jobs:
           TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY }}
           KEEP: 3
         run: |
+          set -euo pipefail
+
           REVISIONS=$(aws ecs list-task-definitions \
             --family-prefix "$TASK_FAMILY" \
             --sort ASC \
             --query 'taskDefinitionArns' \
             --output json | jq -r '.[]')
 
-          TOTAL=$(echo "$REVISIONS" | wc -l | tr -d ' ')
+          if [ -z "$REVISIONS" ]; then
+            echo "Nothing to deregister (no revisions found)."
+            exit 0
+          fi
+
+          TOTAL=$(echo "$REVISIONS" | grep -c .)
           DELETE_COUNT=$(( TOTAL - KEEP ))
 
           if [ "$DELETE_COUNT" -le 0 ]; then

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -165,14 +165,26 @@ data "aws_iam_policy_document" "github_actions_deploy" {
     ]
   }
 
-  # ECS タスク定義の登録・参照 (RegisterTaskDefinition はリソース制限不可のため "*")
+  # ECS タスク定義の登録・参照・一覧 (いずれもリソース制限不可のため "*")
   statement {
     effect = "Allow"
     actions = [
       "ecs:RegisterTaskDefinition",
       "ecs:DescribeTaskDefinition",
+      "ecs:ListTaskDefinitions",
     ]
     resources = ["*"]
+  }
+
+  # 古いタスク定義リビジョンの deregister (対象ファミリーのみに制限)
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecs:DeregisterTaskDefinition",
+    ]
+    resources = [
+      "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:task-definition/${var.app_name}:*",
+    ]
   }
 
   # ECS サービス操作 (対象クラスター・サービスのみに制限)


### PR DESCRIPTION
## 概要

親リポジトリ(algo_sangaku)issue #38「親リポジトリのPRマージに同期して本番環境を更新する仕組みの導入」の実装中に行った Quick Review（code-reviewer/security-reviewer)で、本リポジトリの `autodeploy.yml`/`terraform/iam.tf` に対して以下2点の指摘があったため対応する。

1. `autodeploy.yml` に `concurrency` 設定がなく、連続してリリースをマージした場合にECSへの適用順序が入れ替わりうる（新しいリリースが古いリリースに上書きされる可能性がある）
2. `Deregister old task definition revisions` ステップが、`aws ecs list-task-definitions | jq -r '.[]'` のパイプでAWS側のエラー（実測: `ecs:ListTaskDefinitions` の AccessDeniedException）を握りつぶし、無音のまま成功扱いになっていた。実際に本番環境で古いタスク定義リビジョンが75件以上蓄積し続けていることを実測で確認済み

refs #296

## 確認方法

1. `.github/workflows/autodeploy.yml` の差分をレビューする
   - `concurrency: { group: deploy-production, cancel-in-progress: false }` と `timeout-minutes: 45` を追加
   - `Deregister old task definition revisions` ステップに `set -euo pipefail` を追加し、`REVISIONS` が空の場合の早期リターンを明示化
2. `terraform/iam.tf` の差分をレビューする
   - `ecs:ListTaskDefinitions` を既存の `ecs:RegisterTaskDefinition`/`ecs:DescribeTaskDefinition` と同じ statement（リソース `"*"`、いずれもリソースレベル制限非対応のAWS仕様）に追加
   - `ecs:DeregisterTaskDefinition` を新規 statement として追加。対象タスクファミリー（`arn:aws:ecs:<region>:<account>:task-definition/<app_name>:*`）にリソースを限定
   - `terraform validate` はローカルで通過確認済み
3. **`terraform apply` は本PRの対応範囲外**。本リポジトリにはterraform適用を自動化するCIが存在せず手動運用のため、IAMポリシー変更を実際のAWS環境へ反映する作業は別途実施が必要

## 影響範囲

- `autodeploy.yml`: 本番デプロイ実行時の挙動にのみ影響。通常の1件ずつのリリースでは動作は変わらない
- `terraform/iam.tf`: GitHub Actions用IAMロール(`github_actions_oidc`)の権限追加のみ。既存の権限を狭める変更は含まない。**`terraform apply` 実行までは実際のAWS権限には反映されない**

## チェックリスト

- [x] `terraform validate` をパス
- [x] `.github/workflows/autodeploy.yml` のYAML構文検証
- [ ] `terraform apply` の実施（別途、権限を持つ運用者が対応）
- [ ] マージ後、次回本番デプロイ時に deregister ステップが正常に完了することを確認

## コメント

- 蓄積した既存の75件超の古いタスク定義リビジョンのクリーンアップは本PRのスコープ外。`terraform apply` 後、次回以降のデプロイで自動的に整理される想定
- 本修正は親リポ algo_sangaku の PR #40（issue #38対応）に付随して発見されたもの

🤖 Generated with [Claude Code](https://claude.com/claude-code)