### PR TITLE
fix: autodeploy に不足していた ecr:DescribeImages 権限を追加

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -26,7 +26,7 @@ resource "aws_ecs_task_definition" "main" {
     # --- web (Rails/Puma) ---
     {
       name  = "web"
-      image = "${aws_ecr_repository.rails.repository_url}:latest"
+      image = "${aws_ecr_repository.rails.repository_url}:${var.initial_image_tag}"
       essential = true
 
       entryPoint = ["/algo_sangaku_back/entrypoint.sh"]
@@ -82,7 +82,7 @@ resource "aws_ecs_task_definition" "main" {
     # --- nginx ---
     {
       name  = "nginx"
-      image = "${aws_ecr_repository.nginx.repository_url}:latest"
+      image = "${aws_ecr_repository.nginx.repository_url}:${var.initial_image_tag}"
       essential = true
 
       portMappings = [
@@ -127,7 +127,7 @@ resource "aws_ecs_task_definition" "main" {
     # --- queue (Solid Queue) ---
     {
       name  = "queue"
-      image = "${aws_ecr_repository.rails.repository_url}:latest"
+      image = "${aws_ecr_repository.rails.repository_url}:${var.initial_image_tag}"
       essential = false
 
       entryPoint = ["/algo_sangaku_back/entrypoint-queue.sh"]
@@ -177,7 +177,7 @@ resource "aws_ecs_task_definition" "main" {
   }
 
   # GitHub Actions のデプロイフローがコンテナイメージを管理するため、
-  # terraform apply のたびに :latest タグでタスク定義が上書きされないよう無視する
+  # terraform apply でブートストラップ用のイメージタグに巻き戻らないよう無視する
   lifecycle {
     ignore_changes = [container_definitions]
   }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -154,6 +154,8 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "ecr:BatchCheckLayerAvailability",
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
+      # autodeploy.yml が同タグの存在確認・イメージダイジェスト取得に使用する
+      "ecr:DescribeImages",
       "ecr:PutImage",
       "ecr:InitiateLayerUpload",
       "ecr:UploadLayerPart",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,6 +20,15 @@ variable "app_name" {
   default     = "algo-sangaku"
 }
 
+# 実運用のイメージは autodeploy.yml がデプロイのたびにダイジェスト参照へ書き換えるため、
+# この値が使われるのはゼロから環境を構築するときだけ。ECR に実在するタグを指定すること
+# (:latest は ECR のタグ運用廃止に伴い削除済みのため使用不可)。
+variable "initial_image_tag" {
+  description = "ブートストラップ時にタスク定義が参照する ECR イメージタグ"
+  type        = string
+  default     = "c2b0c62"
+}
+
 # --- VPC ---
 variable "vpc_cidr" {
   description = "VPC の CIDR ブロック"


### PR DESCRIPTION
## 概要

PR #308 で ECR のダイジェスト参照化を導入した際、`autodeploy.yml` に `aws ecr describe-images` を4箇所追加したが、`terraform/iam.tf` の IAM ポリシーへの `ecr:DescribeImages` の追加が漏れていた。このため本番デプロイが失敗していた。

```
An error occurred (AccessDeniedException) when calling the DescribeImages operation:
User: arn:aws:sts::***:assumed-role/***-github-actions-role/GitHubActions is not authorized
to perform: ecr:DescribeImages on resource: arn:aws:ecr:ap-northeast-1:***:repository/***-rails
```

失敗箇所は `Build and push Rails image` 内のダイジェスト取得で、ECS デプロイの**前段**。以降のステップは skip されたため本番への反映は起きていなかった（イメージの push 自体は完了していた）。

issue #307 の `ecs:DeregisterTaskDefinition` に続く2件目の IAM 権限の追随漏れのため、今回は `autodeploy.yml` が呼ぶ AWS API 10種すべてを IAM ポリシーと突き合わせた。不足は `ecr:DescribeImages` の1件のみで、他（`GetAuthorizationToken` / push 系5種 / pull 系2種 / ECS 6種 / `iam:PassRole`）はすべて充足していることを確認済み。

### 変更内容

| ファイル | 変更 |
| --- | --- |
| `terraform/iam.tf` | ECR statement に `ecr:DescribeImages` を追加。このアクションはリソースレベル権限に対応しているため、`ecs:DeregisterTaskDefinition` のときと違い `Resource: "*"` は不要で、既存のリポジトリ ARN 制限のままとした |
| `terraform/variables.tf` | `initial_image_tag` 変数を新設（既定値 `c2b0c62`） |
| `terraform/ecs.tf` | タスク定義の image 3箇所（web / nginx / queue）の `:latest` を `${var.initial_image_tag}` に変更。あわせて `:latest` を前提にしていた `lifecycle` のコメントを修正 |

`:latest` は PR #308 のタグ運用廃止で ECR から削除済みであり、`terraform apply` でタスク定義が再作成されると**存在しないイメージを参照する定義が最新 ACTIVE になる**状態だった。`autodeploy.yml` は `describe-task-definition`（＝最新 ACTIVE）をベースに新リビジョンを作るため、放置すると次回デプロイがその定義を土台にしてしまう。

### state ドリフトの解消（apply 時に実施・コード変更なし）

`terraform state` が INACTIVE な `algo-sangaku:34` を指しており、plan に `aws_ecs_task_definition.main will be created` が出ていた。`KEEP=3` の deregister で terraform 管理下のリビジョンが INACTIVE になったことが原因。稼働中の `algo-sangaku:76` を import して解消し、`No changes` になることを確認した。

## 確認方法

本 PR の変更は `terraform apply` 済みで、本番デプロイの成功も確認済み。レビュー時は以下を確認してください。

1. `terraform plan` が `No changes. Your infrastructure matches the configuration.` になること
2. IAM ポリシーに `ecr:DescribeImages` が含まれること
   ```bash
   aws iam get-role-policy --role-name algo-sangaku-github-actions-role \
     --policy-name algo-sangaku-github-actions-deploy \
     --query 'PolicyDocument.Statement[?contains(to_string(Action), `DescribeImages`)].Action'
   ```
3. `terraform/*.tf` に `:latest` を参照する image 指定が残っていないこと

### 実施済みの動作確認

`workflow_dispatch` で `sha=e28a60d`（`main` の先端）を実行し、全ステップ success を確認した（[実行ログ](https://github.com/Alnoir-0011/algo_sangaku_back/actions/runs/30779545038)）。

| ステップ | 結果 |
| --- | --- |
| Build and push Rails image | `Image tag e28a60d already exists in ***-rails, skipping build/push.`（**修正した権限が機能**。既存タグを検出し ECR の IMMUTABLE 設定との衝突を回避） |
| Build and push nginx image | 新規ビルド・push 成功 |
| Register new ECS task definition | ダイジェスト取得成功（`RAILS_DIGEST` / `NGINX_DIGEST` とも出力） |
| Deploy to ECS | `Deploy succeeded.`（約2分27秒で `rolloutState=COMPLETED`） |
| Deregister old task definition revisions | `Deregistering: .../algo-sangaku:74`（issue #307 で修正した `ecs:DeregisterTaskDefinition` も併せて実証された） |

デプロイ後の実測値:

```
サービス : algo-sangaku:77 / running=1 / pending=0 / deployments=1 / COMPLETED
タスク   : RUNNING / healthStatus=HEALTHY / web・nginx・queue すべて RUNNING
revision : 75, 76, 77（74 が削除され KEEP=3 が機能）
image    : ...rails@sha256:f325633... （タグではなくダイジェスト参照）
外形確認 : GET /up → HTTP 200
```

## 影響範囲

- 本番の IAM ロール `algo-sangaku-github-actions-role` に `ecr:DescribeImages` が追加される（対象は rails / nginx の2リポジトリに限定）
- `terraform/ecs.tf` の image 指定はブートストラップ時のみ使われる値であり、稼働中のタスク定義には影響しない（`lifecycle { ignore_changes = [container_definitions] }` および `aws_ecs_service` 側の `ignore_changes = [task_definition]` により保護されている）
- 本番の稼働イメージは今回のデプロイで `c2b0c62` → `e28a60d` に更新された。両者のアプリケーションコード差分はゼロで、変更は `autodeploy.yml` と `terraform/` の3ファイルのみ
- アプリケーションコード・DB スキーマへの変更はなし

## チェックリスト

- [x] `terraform validate` をパスした
- [x] `terraform fmt -check` で本 PR の変更ファイル（`iam.tf` / `variables.tf`）に指摘がないことを確認した（`ecs.tf` は `main` 時点から既存の整列差分があり、本 PR では変更していない）
- [x] `terraform plan` が `No changes` になることを確認した
- [x] `autodeploy.yml` が呼ぶ AWS API 10種すべてを IAM ポリシーと突き合わせ、他に権限漏れがないことを確認した
- [x] `workflow_dispatch` で本番デプロイを実行し、全ステップ success・タスク HEALTHY・外形 200 を確認した
- [x] `terraform apply` の前に state をバックアップし、`import` 後も plan がクリーンであることを確認した

## コメント

- **既知の制約（今回は対応せず）**: `aws_ecs_task_definition` を terraform の resource として持つ限り、`KEEP=3` の deregister で管理下のリビジョンがいずれ INACTIVE になり、plan に `created` が再び現れる。あと2回デプロイすると今回 import した 76 が対象になる。ただし image を実在するタグに変えたことで、その際に作られる定義は正常なイメージを指すため無害。根本解決（タスク定義を terraform 管理から外し data source 化する案）は、`container_definitions` に含まれる環境変数・SSM secrets・ログ設定が IaC から失われるため採用しなかった
- `initial_image_tag` の既定値 `c2b0c62` は、変更時点で本番稼働中かつ rails / nginx 両リポジトリに実在するタグを選んだ。この値が実際に使われるのはゼロから環境を構築するときだけのため、陳腐化しても実害はない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
