### PR TITLE
test: back/spec の不足テストケースを追加

### DIFF
--- a/spec/controllers/concerns/api/exception_handler_spec.rb
+++ b/spec/controllers/concerns/api/exception_handler_spec.rb
@@ -1,17 +1,42 @@
 require "rails_helper"
 
-class ExceptionHandlerTestController < ActionController::API
-  include Api::ExceptionHandler
-
-  def boom
-    raise StandardError, "boom error"
-  end
-end
-
-RSpec.describe Api::ExceptionHandler, type: :request do
+RSpec.describe Api::ExceptionHandler, type: :request, openapi: false do
   before do
+    stub_const("ExceptionHandlerTestController", Class.new(ActionController::API) do
+      include Api::ExceptionHandler
+
+      def boom
+        raise StandardError, "boom error"
+      end
+
+      def not_found
+        raise ActiveRecord::RecordNotFound, "not found"
+      end
+
+      def parameter_missing
+        raise ActionController::ParameterMissing, :required_param
+      end
+
+      def not_unique
+        raise ActiveRecord::RecordNotUnique, "duplicate key"
+      end
+
+      def invalid
+        raise ActiveRecord::RecordInvalid, User.new
+      end
+
+      def too_many_requests
+        raise TooManyRequestsError.new(reset_at: Time.zone.local(2026, 1, 1, 3, 0, 0))
+      end
+    end)
+
     Rails.application.routes.draw do
       get "exception_handler_test/boom", to: "exception_handler_test#boom"
+      get "exception_handler_test/not_found", to: "exception_handler_test#not_found"
+      get "exception_handler_test/parameter_missing", to: "exception_handler_test#parameter_missing"
+      get "exception_handler_test/not_unique", to: "exception_handler_test#not_unique"
+      get "exception_handler_test/invalid", to: "exception_handler_test#invalid"
+      get "exception_handler_test/too_many_requests", to: "exception_handler_test#too_many_requests"
     end
   end
 
@@ -19,17 +44,73 @@ RSpec.describe Api::ExceptionHandler, type: :request do
     Rails.application.reload_routes!
   end
 
-  it "StandardError 発生時に例外の内容をログに出力すること" do
+  it "logs the exception message when a StandardError occurs" do
     expect(Rails.logger).to receive(:error).with(a_string_including("boom error"))
 
     get "/exception_handler_test/boom"
   end
 
-  it "StandardError 発生時に500を返すこと" do
+  it "returns 500 when a StandardError occurs" do
     allow(Rails.logger).to receive(:error)
 
     get "/exception_handler_test/boom"
 
     expect(response).to have_http_status(:internal_server_error)
+  end
+
+  it "does not include the exception detail in the response when running in production" do
+    allow(Rails.logger).to receive(:error)
+    allow(Rails.env).to receive(:production?).and_return(true)
+
+    get "/exception_handler_test/boom"
+
+    expect(JSON.parse(response.body)["errors"]).to eq []
+  end
+
+  it "includes the exception detail in the response when not running in production" do
+    allow(Rails.logger).to receive(:error)
+
+    get "/exception_handler_test/boom"
+
+    expect(JSON.parse(response.body)["errors"]).to include("boom error")
+  end
+
+  it "returns 404 with the standard not-found message when ActiveRecord::RecordNotFound occurs" do
+    get "/exception_handler_test/not_found"
+
+    expect(response).to have_http_status(:not_found)
+    expect(JSON.parse(response.body)["message"]).to eq "Record Not Found"
+  end
+
+  # render_400 は render_500 と異なり production 環境でも exception&.message をそのまま返す
+  # （detail をマスクしない）。このテストは現状の挙動を記録するものであり、
+  # 「本番でも詳細を返してよい」という仕様保証ではない。マスク対応は issue #312 で追跡する。
+  it "returns 400 with the missing parameter's message when ActionController::ParameterMissing occurs" do
+    get "/exception_handler_test/parameter_missing"
+
+    expect(response).to have_http_status(:bad_request)
+    expect(JSON.parse(response.body)["errors"]).to include(a_string_including("required_param"))
+  end
+
+  it "returns 409 with the standard conflict message when ActiveRecord::RecordNotUnique occurs" do
+    get "/exception_handler_test/not_unique"
+
+    expect(response).to have_http_status(:conflict)
+    expect(JSON.parse(response.body)["message"]).to eq "Conflict"
+  end
+
+  it "returns 409 with the standard conflict message when ActiveRecord::RecordInvalid occurs" do
+    get "/exception_handler_test/invalid"
+
+    expect(response).to have_http_status(:conflict)
+    expect(JSON.parse(response.body)["message"]).to eq "Conflict"
+  end
+
+  # render_429 も render_400 と同様、production 環境でも exception&.message をマスクしない（issue #312）。
+  it "returns 429 and includes reset_at when TooManyRequestsError occurs" do
+    get "/exception_handler_test/too_many_requests"
+
+    expect(response).to have_http_status(:too_many_requests)
+    expect(JSON.parse(response.body)["reset_at"]).to eq Time.zone.local(2026, 1, 1, 3, 0, 0).iso8601
   end
 end

--- a/spec/models/answer_result_spec.rb
+++ b/spec/models/answer_result_spec.rb
@@ -13,5 +13,124 @@ RSpec.describe AnswerResult, type: :model do
       expect(answer_result).to be_valid
       expect(answer_result.errors).to be_empty
     end
+
+    it "is invalid when the same fixed_input already has a result for the same answer" do
+      answer = create(:answer)
+      fixed_input = create(:fixed_input)
+      create(:answer_result, answer:, fixed_input:)
+      duplicate = build(:answer_result, answer:, fixed_input:)
+
+      expect(duplicate).to be_invalid
+      expect(duplicate.errors[:fixed_input_id]).to be_present
+    end
+
+    it "is valid when the same fixed_input has results for different answers" do
+      fixed_input = create(:fixed_input)
+      create(:answer_result, fixed_input:)
+      another = build(:answer_result, fixed_input:)
+
+      expect(another).to be_valid
+      expect(another.errors).to be_empty
+    end
+  end
+
+  describe "#update_status" do
+    let(:sangaku) { create(:sangaku) }
+    let(:user_sangaku_save) { create(:user_sangaku_save, sangaku:) }
+    let(:answer) { create(:answer, user_sangaku_save:) }
+
+    before { allow(answer_result).to receive(:sleep) }
+
+    context "when the fixed_input has an expected_output" do
+      let(:fixed_input) { create(:fixed_input, sangaku:, expected_output: "Hello world\n") }
+      let!(:answer_result) { create(:answer_result, answer:, fixed_input:, status: "pending", output: nil) }
+
+      it "runs only the answer's source and uses the cached expected_output instead of re-running the sangaku source" do
+        expect(answer_result).to receive(:run_source).once.with(answer.source, fixed_input.content).and_call_original
+
+        answer_result.update_status
+
+        expect(answer_result.reload.status).to eq "correct"
+        expect(answer_result.reload.output).to eq "Hello world\n"
+      end
+    end
+
+    context "when the fixed_input has no expected_output" do
+      let(:fixed_input) { create(:fixed_input, sangaku:, expected_output: nil) }
+      let!(:answer_result) { create(:answer_result, answer:, fixed_input:, status: "pending", output: nil) }
+
+      it "runs the answer's source and then the sangaku's source to determine the expected output" do
+        expect(answer_result).to receive(:run_source).with(answer.source, fixed_input.content).ordered.and_call_original
+        expect(answer_result).to receive(:run_source).with(sangaku.source, fixed_input.content).ordered.and_call_original
+
+        answer_result.update_status
+
+        expect(answer_result.reload.status).to eq "correct"
+      end
+    end
+
+    context "when there is no fixed_input" do
+      # sangaku に fixed_input がないため、Answer#create_results により fixed_input: nil の
+      # answer_result が既に1件自動生成されている（uniqueness制約のため二重に作成できない）
+      let!(:answer_result) { answer.answer_results.first }
+
+      it "runs the answer's source and then the sangaku's source with an empty input" do
+        expect(answer_result).to receive(:run_source).with(answer.source, "").ordered.and_call_original
+        expect(answer_result).to receive(:run_source).with(sangaku.source, "").ordered.and_call_original
+
+        answer_result.update_status
+
+        expect(answer_result.reload.status).to eq "correct"
+      end
+    end
+
+    context "when the paizaio response includes stderr" do
+      let(:fixed_input) { create(:fixed_input, sangaku:, expected_output: "Hello world\n") }
+      let!(:answer_result) { create(:answer_result, answer:, fixed_input:, status: "pending", output: nil) }
+
+      it "marks the result incorrect and stores the stderr as the output" do
+        stub_paizaio_api(stderr: "NoMethodError: undefined method\n")
+
+        answer_result.update_status
+
+        expect(answer_result.reload.status).to eq "incorrect"
+        expect(answer_result.reload.output).to eq "NoMethodError: undefined method\n"
+      end
+    end
+
+    context "when the stdout does not match the expected output" do
+      let(:fixed_input) { create(:fixed_input, sangaku:, expected_output: "different output\n") }
+      let!(:answer_result) { create(:answer_result, answer:, fixed_input:, status: "pending", output: nil) }
+
+      it "marks the result incorrect and stores the actual stdout as the output" do
+        answer_result.update_status
+
+        expect(answer_result.reload.status).to eq "incorrect"
+        expect(answer_result.reload.output).to eq "Hello world\n"
+      end
+    end
+  end
+
+  describe "#check_later" do
+    around do |example|
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      example.run
+    ensure
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+
+    it "enqueues a CorrectnessCheckJob after create" do
+      # answer_result factory の answer association が Answer#create_results を発火させ、
+      # sangaku に fixed_inputs が無いため fixed_input: nil の answer_result が追加で1件作られる。
+      # そのため check_later は合計2回呼ばれる。
+      expect { create(:answer_result) }.to have_enqueued_job(CorrectnessCheckJob).exactly(2).times
+    end
+
+    it "does not enqueue a CorrectnessCheckJob on update" do
+      answer_result = create(:answer_result)
+
+      expect { answer_result.update!(status: "correct") }.not_to have_enqueued_job(CorrectnessCheckJob)
+    end
   end
 end

--- a/spec/models/concerns/paizaio_api_spec.rb
+++ b/spec/models/concerns/paizaio_api_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe PaizaioApi, type: :model do
+  before do
+    stub_const("PaizaioApiTestClass", Class.new { include PaizaioApi })
+  end
+
+  subject(:instance) { PaizaioApiTestClass.new }
+
+  describe '#create_runner' do
+    it 'returns the runner id when the request succeeds' do
+      expect(instance.create_runner("puts 1", "ruby", "")).to eq "test_runner_id"
+    end
+
+    it 'raises when the response body contains an error key' do
+      stub_request(:post, "https://api.paiza.io/runners/create.json")
+        .to_return(status: 200, body: { error: "invalid" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect { instance.create_runner("puts 1", "ruby", "") }.to raise_error(StandardError, "コードが実行できませんでした")
+    end
+
+    it 'raises when the response status is not 200' do
+      stub_request(:post, "https://api.paiza.io/runners/create.json")
+        .to_return(status: 500, body: "", headers: {})
+
+      expect { instance.create_runner("puts 1", "ruby", "") }.to raise_error(StandardError, "リクエストに失敗しました")
+    end
+
+    it 'returns nil when the response body has neither an id nor an error key (documents current behavior; see issue #312)' do
+      stub_request(:post, "https://api.paiza.io/runners/create.json")
+        .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect(instance.create_runner("puts 1", "ruby", "")).to be_nil
+    end
+
+    it 'sends the value returned by ENV.fetch("PAIZAIO_API_KEY", "guest") as the api_key parameter' do
+      allow(ENV).to receive(:fetch).with("PAIZAIO_API_KEY", "guest").and_return("configured_key")
+
+      instance.create_runner("puts 1", "ruby", "")
+
+      expect(WebMock).to have_requested(:post, "https://api.paiza.io/runners/create.json")
+        .with(body: hash_including("api_key" => "configured_key"))
+    end
+
+    it 'falls back to the guest api_key when PAIZAIO_API_KEY is not configured' do
+      allow(ENV).to receive(:fetch).with("PAIZAIO_API_KEY", "guest").and_return("guest")
+
+      instance.create_runner("puts 1", "ruby", "")
+
+      expect(WebMock).to have_requested(:post, "https://api.paiza.io/runners/create.json")
+        .with(body: hash_including("api_key" => "guest"))
+    end
+  end
+
+  describe '#get_status' do
+    it 'returns the status when the request succeeds' do
+      expect(instance.get_status("test_runner_id")).to eq "completed"
+    end
+
+    it 'raises when the response body is missing the status key' do
+      stub_request(:get, /api\.paiza\.io.*get_status/)
+        .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect { instance.get_status("test_runner_id") }.to raise_error(StandardError, "idが無効です")
+    end
+
+    it 'raises when the response status is not 200' do
+      stub_request(:get, /api\.paiza\.io.*get_status/)
+        .to_return(status: 500, body: "", headers: {})
+
+      expect { instance.get_status("test_runner_id") }.to raise_error(StandardError, "リクエストに失敗しました")
+    end
+  end
+
+  describe '#get_details' do
+    it 'returns the response body when the request succeeds' do
+      expect(instance.get_details("test_runner_id")["stdout"]).to eq "Hello world\n"
+    end
+
+    it 'raises when the response body is missing the stdout key' do
+      stub_request(:get, /api\.paiza\.io.*get_details/)
+        .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect { instance.get_details("test_runner_id") }.to raise_error(StandardError, "idが無効です")
+    end
+
+    it 'raises when the response status is not 200' do
+      stub_request(:get, /api\.paiza\.io.*get_details/)
+        .to_return(status: 500, body: "", headers: {})
+
+      expect { instance.get_details("test_runner_id") }.to raise_error(StandardError, "リクエストに失敗しました")
+    end
+  end
+
+  describe '#run_source' do
+    it 'polls until the status is no longer running and returns the details' do
+      allow(instance).to receive(:sleep)
+
+      result = instance.run_source("puts 1")
+
+      expect(result["stdout"]).to eq "Hello world\n"
+    end
+
+    it 'polls multiple times before the status becomes completed' do
+      allow(instance).to receive(:sleep)
+      allow(instance).to receive(:get_status).and_return("running", "running", "completed")
+
+      result = instance.run_source("puts 1")
+
+      expect(result["stdout"]).to eq "Hello world\n"
+      expect(instance).to have_received(:get_status).exactly(3).times
+    end
+
+    it 'raises a polling timeout error after exhausting the max poll attempts' do
+      allow(instance).to receive(:sleep)
+      allow(instance).to receive(:get_status).and_return("running")
+
+      expect { instance.run_source("puts 1") }.to raise_error(StandardError, "PaizaIO polling timeout")
+    end
+  end
+end

--- a/spec/models/concerns/spherical_cosine_theorem_spec.rb
+++ b/spec/models/concerns/spherical_cosine_theorem_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe SphericalCosineTheorem, type: :model do
+  before do
+    stub_const("SphericalCosineTheoremTestClass", Class.new { include SphericalCosineTheorem })
+  end
+
+  describe '#distance' do
+    subject(:instance) { SphericalCosineTheoremTestClass.new }
+
+    it 'returns 0 when the two points are identical' do
+      shrine = build(:shrine, latitude: 35.4, longitude: 135.1)
+
+      expect(instance.distance(shrine, 35.4, 135.1)).to be_within(1e-9).of(0)
+    end
+
+    it 'does not raise even when floating point rounding pushes the cosine argument out of range' do
+      # 1つ目のテストと入力（座標）は同一だが、検証観点が異なる独立したテスト:
+      # cos(lat1)*cos(lat2)*cos(lng2-lng1) + sin(lat1)*sin(lat2) は同一点では
+      # 理論上ちょうど1.0だが、浮動小数点の丸め誤差で1.0をわずかに超えることがある。
+      # clamp(-1.0, 1.0) が無いと Math.acos が Math::DomainError を発生させるため、
+      # その回帰を防ぐことを目的としたテスト。
+      shrine = build(:shrine, latitude: 35.681236, longitude: 139.767125)
+
+      expect { instance.distance(shrine, 35.681236, 139.767125) }.not_to raise_error
+    end
+
+    it 'returns approximately 111.19km for a 1 degree difference in latitude' do
+      shrine = build(:shrine, latitude: 0, longitude: 0)
+
+      expect(instance.distance(shrine, 1, 0)).to be_within(0.1).of(111.19)
+    end
+
+    it 'returns approximately 111.19km for a 1 degree difference in longitude at the equator' do
+      shrine = build(:shrine, latitude: 0, longitude: 0)
+
+      expect(instance.distance(shrine, 0, 1)).to be_within(0.1).of(111.19)
+    end
+
+    it 'returns a smaller distance for a 1 degree difference in longitude than in latitude away from the equator' do
+      shrine = build(:shrine, latitude: 80, longitude: 0)
+
+      lat_diff_distance = instance.distance(shrine, 81, 0)
+      lng_diff_distance = instance.distance(shrine, 80, 1)
+
+      expect(lng_diff_distance).to be < lat_diff_distance
+    end
+  end
+end

--- a/spec/models/sangaku_spec.rb
+++ b/spec/models/sangaku_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Sangaku, type: :model do
   describe 'validation' do
-    it 'is valid with all attribute' do
+    it 'is valid with all attributes' do
       sangaku = build(:sangaku)
       expect(sangaku).to be_valid
       expect(sangaku.errors).to be_empty
@@ -74,7 +74,38 @@ RSpec.describe Sangaku, type: :model do
     end
   end
 
+  # lat/lng はクライアント（HTTPリクエストパラメータ）からそのまま渡される申告値であり、
+  # このテストはあくまで距離計算に基づく閾値判定ロジックの正しさを検証するもの。
+  # サーバー側で位置情報の真正性を検証していないため、この距離チェックはUX上の制約であり
+  # 位置偽装（なりすまし奉納）に対するセキュリティ境界にはならない（issue #312 で対応方針を検討）。
   describe '#dedicate' do
+    it 'dedicates the sangaku when the distance is within the default threshold' do
+      sangaku = create(:sangaku, shrine: nil)
+      shrine = create(:shrine, latitude: 35.4, longitude: 135.1)
+
+      expect(sangaku.dedicate(shrine, 35.4, 135.1)).to eq true
+      expect(sangaku.reload.shrine).to eq shrine
+    end
+
+    it 'does not dedicate the sangaku when the distance exceeds the default threshold' do
+      sangaku = create(:sangaku, shrine: nil)
+      shrine = create(:shrine, latitude: 35.4, longitude: 135.1)
+
+      expect(sangaku.dedicate(shrine, 35.41, 135.1)).to eq false
+      expect(sangaku.reload.shrine).to be_nil
+    end
+
+    it 'does not dedicate the sangaku when it already has a shrine, regardless of distance' do
+      existing_shrine = create(:shrine, latitude: 35.4, longitude: 135.1)
+      sangaku = create(:sangaku, shrine: existing_shrine)
+      # 意図的に existing_shrine と異なる座標にし、「距離判定ではなく既存shrineの有無で
+      # 短絡的に弾かれている」ことを明確にする
+      new_shrine = create(:shrine, latitude: 43.0, longitude: 141.3)
+
+      expect(sangaku.dedicate(new_shrine, 43.0, 141.3)).to eq false
+      expect(sangaku.reload.shrine).to eq existing_shrine
+    end
+
     it 'returns false when save! raises ActiveRecord::RecordInvalid' do
       sangaku = create(:sangaku)
       shrine = create(:shrine)

--- a/spec/models/shrine_spec.rb
+++ b/spec/models/shrine_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Shrine, type: :model do
     end
 
 
-    it "is invalid with out address" do
+    it "is invalid without address" do
       shrine = build(:shrine, address: "")
       expect(shrine).to be_invalid
       expect(shrine.errors[:address]).to eq [ 'を入力してください' ]
@@ -59,7 +59,7 @@ RSpec.describe Shrine, type: :model do
       expect(another_shirne.errors[:place_id]).to eq [ 'はすでに存在します' ]
     end
 
-    it "is valid with anotehr place_id" do
+    it "is valid with another place_id" do
       create(:shrine)
       another_shirne = build(:shrine, place_id: "another_place_id")
       expect(another_shirne).to be_valid
@@ -120,6 +120,70 @@ RSpec.describe Shrine, type: :model do
       allow(Shrine).to receive(:text_search_by_location_bias).and_raise(PlaceApiRequestFailedError.new("500"))
 
       expect { Shrine.search_by_location(1, 2) }.to raise_error(PlaceApiRequestFailedError)
+    end
+  end
+
+  # eleminate_non_shrine はクラス内で private 宣言されているが、Ruby の private は
+  # def self.foo 形式のクラスメソッド（特異メソッド）には効かないため実際は public で呼び出せる
+  # （可視性を意図通りにする対応は issue #312 で追跡）。
+  # 除外条件の組み合わせ（キーワード×「社」と「寺」の同時一致）が複雑で、
+  # .search_by_bounds/.search_by_location 経由の間接テストだけでは全分岐を網羅しづらいため、直接呼び出して検証する
+  describe '.eleminate_non_shrine' do
+    def place_with_name(name)
+      { "displayName" => { "text" => name } }
+    end
+
+    it 'returns an empty array when given no places' do
+      expect(Shrine.send(:eleminate_non_shrine, [])).to eq []
+    end
+
+    it 'keeps a place whose name has no eliminate keywords' do
+      places = [ place_with_name("〇〇神社") ]
+
+      expect(Shrine.send(:eleminate_non_shrine, places)).to eq places
+    end
+
+    it 'excludes a place whose name includes 寺' do
+      places = [ place_with_name("〇〇寺") ]
+
+      expect(Shrine.send(:eleminate_non_shrine, places)).to eq []
+    end
+
+    it 'excludes a place whose name includes 手水舎' do
+      places = [ place_with_name("〇〇神社 手水舎") ]
+
+      expect(Shrine.send(:eleminate_non_shrine, places)).to eq []
+    end
+
+    it 'excludes a place whose name includes 社務所' do
+      places = [ place_with_name("〇〇神社務所") ]
+
+      expect(Shrine.send(:eleminate_non_shrine, places)).to eq []
+    end
+
+    it 'excludes a place whose name includes 授与所' do
+      places = [ place_with_name("〇〇神社授与所") ]
+
+      expect(Shrine.send(:eleminate_non_shrine, places)).to eq []
+    end
+
+    it 'excludes a place whose name includes 鳥居' do
+      places = [ place_with_name("〇〇神社鳥居") ]
+
+      expect(Shrine.send(:eleminate_non_shrine, places)).to eq []
+    end
+
+    it 'keeps a place whose name includes both 社 and 寺 despite matching the 寺 keyword' do
+      places = [ place_with_name("〇〇神社(旧〇〇寺)") ]
+
+      expect(Shrine.send(:eleminate_non_shrine, places)).to eq places
+    end
+
+    it 'filters a mixed list down to only the eligible places' do
+      keep = place_with_name("〇〇神社")
+      drop = place_with_name("〇〇寺")
+
+      expect(Shrine.send(:eleminate_non_shrine, [ keep, drop ])).to eq [ keep ]
     end
   end
 end

--- a/spec/models/user_sangaku_save_spec.rb
+++ b/spec/models/user_sangaku_save_spec.rb
@@ -1,5 +1,105 @@
 require 'rails_helper'
 
 RSpec.describe UserSangakuSave, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validation' do
+    it 'is valid with all attributes' do
+      user_sangaku_save = build(:user_sangaku_save)
+      expect(user_sangaku_save).to be_valid
+      expect(user_sangaku_save.errors).to be_empty
+    end
+
+    it 'is invalid when the same user saves the same sangaku twice' do
+      user = create(:user)
+      sangaku = create(:sangaku)
+      create(:user_sangaku_save, user:, sangaku:)
+      another_save = build(:user_sangaku_save, user:, sangaku:)
+
+      expect(another_save).to be_invalid
+      expect(another_save.errors[:sangaku_id]).to eq [ 'はすでに存在します' ]
+    end
+
+    it 'is valid when different users save the same sangaku' do
+      sangaku = create(:sangaku)
+      create(:user_sangaku_save, sangaku:)
+      another_save = build(:user_sangaku_save, sangaku:)
+
+      expect(another_save).to be_valid
+      expect(another_save.errors).to be_empty
+    end
+
+    it 'is valid when the same user saves a different sangaku' do
+      user = create(:user)
+      create(:user_sangaku_save, user:)
+      another_save = build(:user_sangaku_save, user:)
+
+      expect(another_save).to be_valid
+      expect(another_save.errors).to be_empty
+    end
+
+    it 'is invalid without a user' do
+      user_sangaku_save = build(:user_sangaku_save, user: nil)
+
+      expect(user_sangaku_save).to be_invalid
+      expect(user_sangaku_save.errors[:user]).to be_present
+    end
+
+    it 'is invalid without a sangaku' do
+      user_sangaku_save = build(:user_sangaku_save, sangaku: nil)
+
+      expect(user_sangaku_save).to be_invalid
+      expect(user_sangaku_save.errors[:sangaku]).to be_present
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to user' do
+      user_sangaku_save = build(:user_sangaku_save)
+      expect(user_sangaku_save.user).to be_a(User)
+    end
+
+    it 'belongs to sangaku' do
+      user_sangaku_save = build(:user_sangaku_save)
+      expect(user_sangaku_save.sangaku).to be_a(Sangaku)
+    end
+
+    it 'has one answer' do
+      user_sangaku_save = create(:user_sangaku_save)
+      answer = create(:answer, user_sangaku_save:)
+
+      expect(user_sangaku_save.reload.answer).to eq answer
+    end
+  end
+
+  describe '#destroy' do
+    it 'destroys the associated answer' do
+      user_sangaku_save = create(:user_sangaku_save)
+      answer = create(:answer, user_sangaku_save:)
+
+      user_sangaku_save.destroy!
+
+      expect(Answer.exists?(answer.id)).to eq false
+    end
+  end
+
+  describe '.unanswered' do
+    it 'returns saves without an answer and excludes saves with an answer' do
+      unanswered_save = create(:user_sangaku_save)
+      answered_save = create(:user_sangaku_save)
+      create(:answer, user_sangaku_save: answered_save)
+
+      expect(UserSangakuSave.unanswered).to include(unanswered_save)
+      expect(UserSangakuSave.unanswered).not_to include(answered_save)
+    end
+  end
+
+  describe '.answered' do
+    it 'returns saves with an answer and excludes saves without an answer' do
+      unanswered_save = create(:user_sangaku_save)
+      answered_save = create(:user_sangaku_save)
+      create(:answer, user_sangaku_save: answered_save)
+
+      expect(UserSangakuSave.answered).to include(answered_save)
+      expect(UserSangakuSave.answered).not_to include(unanswered_save)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe "validation" do
-    it "is valid with all attribute" do
+    it "is valid with all attributes" do
       user = build(:user)
       expect(user).to be_valid
       expect(user.errors).to be_empty
@@ -67,7 +67,7 @@ RSpec.describe User, type: :model do
       expect(another_user.errors[:email]).to eq [ 'はすでに存在します' ]
     end
 
-    it "is valid with another eamil" do
+    it "is valid with another email" do
       create(:user)
       another_user = build(:user, email: "another_user@example.com")
       expect(another_user).to be_valid
@@ -83,7 +83,7 @@ RSpec.describe User, type: :model do
 
     it "is valid with same nickname" do
       user = create(:user)
-      another_user = build(:user, email: user.nickname)
+      another_user = build(:user, nickname: user.nickname)
       expect(another_user).to be_valid
       expect(another_user.errors).to be_empty
     end
@@ -163,6 +163,92 @@ RSpec.describe User, type: :model do
           expect(user.generate_source_daily_reset_at).to eq Time.zone.local(2026, 4, 11, 3, 0, 0)
         end
       end
+    end
+  end
+
+  describe "#add_saved_sangakus" do
+    it "adds the sangaku to the user's saved sangakus" do
+      user = create(:user)
+      sangaku = create(:sangaku)
+
+      user.add_saved_sangakus(sangaku)
+
+      expect(user.saved_sangakus).to include(sangaku)
+    end
+  end
+
+  describe "#dedicated_sangakus_with_shrine" do
+    it "returns only sangakus that have a shrine" do
+      user = create(:user)
+      shrine = create(:shrine)
+      dedicated_sangaku = create(:sangaku, user:, shrine:)
+      create(:sangaku, user:, shrine: nil)
+
+      expect(user.dedicated_sangakus_with_shrine).to eq [ dedicated_sangaku ]
+    end
+
+    it "memoizes the result across calls" do
+      user = create(:user)
+      shrine = create(:shrine)
+      create(:sangaku, user:, shrine:)
+
+      first_call = user.dedicated_sangakus_with_shrine
+      create(:sangaku, user:, shrine: create(:shrine))
+
+      expect(user.dedicated_sangakus_with_shrine).to equal(first_call)
+    end
+  end
+
+  describe ".search" do
+    it "matches users whose email partially matches the query" do
+      matching_user = create(:user, email: "taro@example.com")
+      create(:user, email: "other@example.com")
+
+      expect(User.search("taro")).to include(matching_user)
+      expect(User.search("taro").count).to eq 1
+    end
+
+    it "matches users whose nickname partially matches the query" do
+      matching_user = create(:user, nickname: "algo_taro")
+      create(:user, nickname: "other")
+
+      expect(User.search("taro")).to include(matching_user)
+    end
+
+    it "is case-insensitive" do
+      matching_user = create(:user, nickname: "AlgoTaro")
+
+      expect(User.search("algotaro")).to include(matching_user)
+    end
+
+    it "escapes the percent wildcard instead of matching every user" do
+      literal_percent_user = create(:user, nickname: "50%off")
+      other_user = create(:user, nickname: "regular")
+
+      result = User.search("%")
+
+      expect(result).to include(literal_percent_user)
+      expect(result).not_to include(other_user)
+    end
+
+    it "escapes the underscore wildcard instead of matching any single character" do
+      literal_underscore_user = create(:user, nickname: "a_b")
+      other_user = create(:user, nickname: "aXb")
+
+      result = User.search("a_b")
+
+      expect(result).to include(literal_underscore_user)
+      expect(result).not_to include(other_user)
+    end
+
+    it "escapes backslash characters in the query" do
+      literal_backslash_user = create(:user, nickname: "a\\b")
+      other_user = create(:user, nickname: "ab")
+
+      result = User.search("a\\b")
+
+      expect(result).to include(literal_backslash_user)
+      expect(result).not_to include(other_user)
     end
   end
 end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "Health", type: :request, openapi: false do
+  describe "GET /health" do
+    it "returns ok when the database connection succeeds" do
+      get "/health"
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq("status" => "ok")
+    end
+
+    it "returns service_unavailable and logs the error when the database connection fails" do
+      allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(StandardError, "connection lost")
+      expect(Rails.logger).to receive(:error).with(a_string_including("connection lost"))
+
+      get "/health"
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(JSON.parse(response.body)).to eq("status" => "error")
+    end
+  end
+end


### PR DESCRIPTION
## 概要

`back/spec` で不足していたテストケースを追加した。対象は以下の未検証だったロジック:

- `UserSangakuSave`（pending placeholder → validation/associations/#destroy/scopeの実テスト）
- `SphericalCosineTheorem#distance`（新規）
- `PaizaioApi`（`create_runner`/`get_status`/`get_details`の異常系、`run_source`のポーリングタイムアウト）（新規）
- `AnswerResult#update_status`（`expected_output`有無の分岐、`fixed_input_id`のuniqueness、`check_later`コールバック）
- `Shrine.eleminate_non_shrine`（除外キーワード・特殊分岐）
- `User#add_saved_sangakus`, `#dedicated_sangakus_with_shrine`, `scope :search`
- `Api::ExceptionHandler`（各例外→HTTPステータスの分岐、production環境でのdetail抑制）
- `HealthController`（新規、正常系・DB接続失敗時）
- `Sangaku#dedicate`（距離ベースの成功/失敗ケース）

追加後、`code-reviewer`/`security-reviewer` サブエージェントによるレビューを実施し、指摘のうちテスト側で対応可能なものを反映した:

- `run_source` の呼び出し引数（`answer.source`/`sangaku.source`）を検証するよう強化（正誤判定バイパスのリグレッション検知）
- `sleep` のスタブ漏れを解消（実行時間短縮）
- `check_later` のジョブenqueue数を実態通り `exactly(2).times` に修正
- `PAIZAIO_API_KEY` の `guest` フォールバック、`id`/`error` 欠落分岐のテストを追加
- テスト用ダミークラス/コントローラを `stub_const` でグローバル名前空間から分離
- LIKE ワイルドカード（`_`・`\`）のエスケープテストを追加
- 実装コードの修正が必要な項目（`Shrine.eleminate_non_shrine` の除外バイパスバグ等）は #312 にまとめて別issue化

## 確認方法

```bash
docker-compose exec web bundle exec rspec
```

361 examples, 0 failures を確認済み。

## 影響範囲

`back/spec/` 配下のみ。実装コード（`app/` 以下）の変更なし。

## チェックリスト

- [x] ユニットテストをパスした（361 examples, 0 failures）
- [x] レビュー指摘のうちテストで対応可能なものを反映した
- [ ] 実装コード側の修正は #312 で別途対応

## コメント

レビューで発見した実装コード側の不具合・改善点（Blocker 1件、Major 4件、Minor 3件）は #312 にまとめている。特に `Shrine.eleminate_non_shrine`（`app/models/shrine.rb:59-61`）の除外バイパスバグは、テストのみでは検出できない実装側の既存バグとして issue に記載済み。